### PR TITLE
Add `truncate-chars` handlebars helper

### DIFF
--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -1306,7 +1306,9 @@ Following variables are available:
 
 Following helpers are available:
 - &lt;tt&gt;filename-from-uri&lt;/tt&gt;
-- &lt;tt&gt;hostname-from-uri&lt;/tt&gt;</property>
+- &lt;tt&gt;hostname-from-uri&lt;/tt&gt;
+- &lt;tt&gt;truncate-chars&lt;/tt&gt;
+      example: &lt;tt&gt;{{truncate-chars window-title 20}}&lt;/tt&gt;</property>
                         <property name="use-markup">True</property>
                         <property name="wrap">True</property>
                         <property name="xalign">0</property>

--- a/terminalpage.js
+++ b/terminalpage.js
@@ -48,6 +48,13 @@ Handlebars.registerHelper('hostname-from-uri', uri => {
     return '';
 });
 
+Handlebars.registerHelper('truncate-chars', (str, length) => {
+    if (str.length > length)
+        return `${str.slice(0, length)}…`;
+
+    return str;
+});
+
 const PCRE2_UTF = 0x00080000;
 const PCRE2_NO_UTF_CHECK = 0x40000000;
 const PCRE2_UCP = 0x00020000;


### PR DESCRIPTION
Using this helper, user can set a maximum length on tab titles (like tilda `Title Max Length` option in tilda).

Without this option, tabs can get too large:

![image](https://user-images.githubusercontent.com/2115303/136744434-f83a6af1-ca6a-42bf-ac02-85e02ca95448.png)

Using `{{truncate-chars window-title 20}}`:

![image](https://user-images.githubusercontent.com/2115303/136744624-da632a58-c053-4772-839f-c3cc1971ce75.png)
