### PR TITLE
Update default bindings to be consistent with other gnome projects

### DIFF
--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -419,7 +419,7 @@
       <default><![CDATA[[]]]></default>
     </key>
     <key name="shortcut-win-new-tab" type="as">
-      <default><![CDATA[['<Ctrl><Shift>n']]]></default>
+      <default><![CDATA[['<Ctrl><Shift>t']]]></default>
     </key>
     <key name="shortcut-win-new-tab-front" type="as">
       <default><![CDATA[[]]]></default>
@@ -431,7 +431,7 @@
       <default><![CDATA[[]]]></default>
     </key>
     <key name="shortcut-page-close" type="as">
-      <default><![CDATA[['<Ctrl><Shift>q']]]></default>
+      <default><![CDATA[['<Ctrl><Shift>w']]]></default>
     </key>
     <key name="shortcut-prev-tab" type="as">
       <default><![CDATA[['<Ctrl>Page_Up']]]></default>


### PR DESCRIPTION
Other gnome applications such as gnome-terminal use `Ctrl+Shift+t` to open a new tab and `Ctrl+Shift+w` to close tabs. Nautilus uses `Ctrl+t` and `Ctrl+w` and so do most browsers. I think it would be nice to align with these commands since most people will have learned this and it would be nice if this carried over to this terminal also.