### PR TITLE
panelicon: use symbolic icon

### DIFF
--- a/ddterm/shell/panelicon.js
+++ b/ddterm/shell/panelicon.js
@@ -55,7 +55,7 @@ const PanelIconBase = GObject.registerClass(
             this.connections = new ConnectionSet();
 
             this.add_actor(new St.Icon({
-                icon_name: 'utilities-terminal-symbolic',
+                icon_name: 'terminal-symbolic',
                 style_class: 'system-status-icon',
             }));
 

--- a/ddterm/shell/panelicon.js
+++ b/ddterm/shell/panelicon.js
@@ -55,7 +55,7 @@ const PanelIconBase = GObject.registerClass(
             this.connections = new ConnectionSet();
 
             this.add_actor(new St.Icon({
-                icon_name: 'utilities-terminal',
+                icon_name: 'utilities-terminal-symbolic',
                 style_class: 'system-status-icon',
             }));
 


### PR DESCRIPTION
Append `-symbolic` to the panel icon name, to make sure the symbolic variant is used. Although, this seems not to be needed for the default Adwaita icon theme, it is so for third-party icon themes.

Here's a comparison, using Papirus icon pack:
| Before | After |
|--------|-------|
| ![Screenshot from 2023-01-29 20-45-15](https://user-images.githubusercontent.com/65264536/215363884-6c7c3e54-25dd-425a-87fc-3b846c95c7f4.png) | ![Screenshot from 2023-01-29 20-46-45](https://user-images.githubusercontent.com/65264536/215363881-691f35fc-0e75-4a7a-9a4d-56509b400cc3.png)| 

The `utilities-terminal-symbolic` icon is also available on the Adwaita icon theme, so this change does not break the default experience as you can see below.

![image](https://user-images.githubusercontent.com/65264536/215364207-8d7f7981-25b7-498d-a87b-58d6ce70b1ac.png)

