### PR TITLE
dbus activation: add dbus service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ PACK_CONTENT += \
 	ddterm/app/dependencies.json \
 	ddterm/com.github.amezin.ddterm.Extension.xml \
 	ddterm/com.github.amezin.ddterm.desktop \
-	ddterm/org.gnome.Shell.Extensions.ddterm.service \
+	ddterm/com.github.amezin.ddterm.service \
 	LICENSE \
 
 PACK_CONTENT := $(sort $(PACK_CONTENT))

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ PACK_CONTENT += \
 	ddterm/app/dependencies.json \
 	ddterm/com.github.amezin.ddterm.Extension.xml \
 	ddterm/com.github.amezin.ddterm.desktop \
+	ddterm/org.gnome.Shell.Extensions.ddterm.service \
 	LICENSE \
 
 PACK_CONTENT := $(sort $(PACK_CONTENT))

--- a/ddterm/com.github.amezin.ddterm.desktop
+++ b/ddterm/com.github.amezin.ddterm.desktop
@@ -7,3 +7,4 @@ Icon=utilities-terminal
 Exec=gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/ddterm --method com.github.amezin.ddterm.Extension.Activate
 Categories=Utility;
 StartupWMClass=Com.github.amezin.ddterm
+DBusActivatable=true

--- a/ddterm/com.github.amezin.ddterm.service
+++ b/ddterm/com.github.amezin.ddterm.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
-Name=org.gnome.Shell.Extensions.ddterm
+Name=com.github.amezin.ddterm
 Exec=gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/ddterm --method com.github.amezin.ddterm.Extension.Activate

--- a/ddterm/org.gnome.Shell.Extensions.ddterm.service
+++ b/ddterm/org.gnome.Shell.Extensions.ddterm.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.gnome.Shell.Extensions.ddterm
+Exec=gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/ddterm --method com.github.amezin.ddterm.Extension.Activate

--- a/ddterm/shell/extension.js
+++ b/ddterm/shell/extension.js
@@ -262,6 +262,19 @@ function enable() {
             ]))
     );
     dbus_service.install();
+
+    Gio.DBus.session.call(
+        'org.freedesktop.DBus',
+        'org/freedesktop/DBus',
+        'org.freedesktop.DBus',
+        'ReloadConfig',
+        null,
+        null,
+        Gio.DBusCallFlags.NONE,
+        -1,
+        null,
+        null,
+    )
 }
 
 function disable() {

--- a/ddterm/shell/extension.js
+++ b/ddterm/shell/extension.js
@@ -44,6 +44,7 @@ let window_connections = null;
 let dbus_interface = null;
 
 let desktop_entry = null;
+let dbus_service = null;
 
 const APP_ID = 'com.github.amezin.ddterm';
 const APP_WMCLASS = 'Com.github.amezin.ddterm';
@@ -142,16 +143,10 @@ class ExtensionDBusInterface {
     }
 }
 
-class DesktopEntry {
-    constructor() {
-        this.source_file = Me.dir.get_child('ddterm').get_child('com.github.amezin.ddterm.desktop');
-        this.target_file = Gio.File.new_for_path(GLib.build_filenamev(
-            [
-                GLib.get_user_data_dir(),
-                'applications',
-                `${APP_ID}.desktop`,
-            ]
-        ));
+class InstallableResource {
+    constructor(source_file, target_file) {
+        this.source_file = source_file;
+        this.target_file = target_file;
     }
 
     install() {
@@ -245,8 +240,28 @@ function enable() {
         watch_window(actor.meta_window);
     });
 
-    desktop_entry = new DesktopEntry();
+    desktop_entry = new InstallableResource(
+        Me.dir.get_child('ddterm').get_child('com.github.amezin.ddterm.desktop'),
+        Gio.File.new_for_path(GLib.build_filenamev(
+            [
+                GLib.get_user_data_dir(),
+                'applications',
+                `${APP_ID}.desktop`,
+            ]))
+    );
     desktop_entry.install();
+
+    dbus_service = new InstallableResource(
+        Me.dir.get_child('ddterm').get_child('org.gnome.Shell.Extensions.ddterm.service'),
+        Gio.File.new_for_path(GLib.build_filenamev(
+            [
+                GLib.get_user_runtime_dir(),
+                'dbus-1',
+                'services',
+                'org.gnome.Shell.Extensions.ddterm.service',
+            ]))
+    );
+    dbus_service.install();
 }
 
 function disable() {
@@ -301,6 +316,11 @@ function disable() {
             desktop_entry.uninstall();
 
         desktop_entry = null;
+    }
+
+    if (dbus_service) {
+        dbus_service.uninstall();
+        dbus_service = null;
     }
 
     settings = null;

--- a/ddterm/shell/extension.js
+++ b/ddterm/shell/extension.js
@@ -273,8 +273,8 @@ function enable() {
         Gio.DBusCallFlags.NONE,
         -1,
         null,
-        null,
-    )
+        null
+    );
 }
 
 function disable() {

--- a/ddterm/shell/extension.js
+++ b/ddterm/shell/extension.js
@@ -252,13 +252,13 @@ function enable() {
     desktop_entry.install();
 
     dbus_service = new InstallableResource(
-        Me.dir.get_child('ddterm').get_child('org.gnome.Shell.Extensions.ddterm.service'),
+        Me.dir.get_child('ddterm').get_child('com.github.amezin.ddterm.service'),
         Gio.File.new_for_path(GLib.build_filenamev(
             [
                 GLib.get_user_runtime_dir(),
                 'dbus-1',
                 'services',
-                'org.gnome.Shell.Extensions.ddterm.service',
+                'com.github.amezin.ddterm.service',
             ]))
     );
     dbus_service.install();


### PR DESCRIPTION
First, refactor the `DesktopEntry` class into a more generic `InstallableResource` class, that doesn't have pre-defined values for `source_file` and `target_file`, and can be used for both the desktop entry file and the dbus service file.

Then, create an instance of this new class for the dbus file and install it to a subdirectory of the user's runtime directory $XDG_RUNTIME_DIR, where the dbus daemon looks for these files.

If merged, this would solve issue #304.
