### PR TITLE
panelicon: unify toggle and menu panel icons

### DIFF
--- a/ddterm/pref/glade/prefs-panel-icon.ui
+++ b/ddterm/pref/glade/prefs-panel-icon.ui
@@ -54,7 +54,6 @@ along with ddterm GNOME Shell extension.  If not, see <http://www.gnu.org/licens
         <items>
           <item id="none" translatable="yes">None</item>
           <item id="menu-button" translatable="yes">With popup menu</item>
-          <item id="toggle-button" translatable="yes">Toggle button</item>
         </items>
       </object>
       <packing>

--- a/ddterm/shell/panelicon.js
+++ b/ddterm/shell/panelicon.js
@@ -95,28 +95,6 @@ const PanelIconPopupMenu = GObject.registerClass(
         }
 
         set active(value) {
-            this.toggle_item.setToggleState(value);
-        }
-
-        static type_name() {
-            return 'menu-button';
-        }
-    }
-);
-
-const PanelIconToggleButton = GObject.registerClass(
-    class DDTermPanelIconToggleButton extends PanelIconBase {
-        _init() {
-            super._init(true);
-
-            this.accessible_role = Atk.Role.TOGGLE_BUTTON;
-        }
-
-        get active() {
-            return this.has_style_pseudo_class('active');
-        }
-
-        set active(value) {
             if (value === this.active)
                 return;
 
@@ -128,18 +106,22 @@ const PanelIconToggleButton = GObject.registerClass(
                 this.remove_accessible_state(Atk.StateType.CHECKED);
             }
 
-            this.notify('active');
+            this.toggle_item.setToggleState(value);
         }
 
         static type_name() {
-            return 'toggle-button';
+            return 'menu-button';
         }
 
         vfunc_event(event) {
-            if (event.type() === Clutter.EventType.BUTTON_PRESS ||
-                event.type() === Clutter.EventType.TOUCH_BEGIN)
-                this.emit('toggle', !this.active);
-
+            if (event.type() === Clutter.EventType.TOUCH_BEGIN ||
+                event.type() === Clutter.EventType.BUTTON_PRESS) {
+                if (event.get_button() === Clutter.BUTTON_PRIMARY ||
+                    event.get_button() === Clutter.BUTTON_MIDDLE)
+                    this.emit('toggle', !this.active);
+                else
+                    super.vfunc_event(event);
+            }
             return Clutter.EVENT_PROPAGATE;
         }
     }
@@ -183,7 +165,6 @@ var PanelIconProxy = GObject.registerClass(
             };
 
             this.types[PanelIconPopupMenu.type_name()] = PanelIconPopupMenu;
-            this.types[PanelIconToggleButton.type_name()] = PanelIconToggleButton;
         }
 
         get type() {

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -135,7 +135,6 @@
   <enum id="com.github.amezin.ddterm.PanelIconType">
     <value nick="none" value="0"/>
     <value nick="menu-button" value="1"/>
-    <value nick="toggle-button" value="2"/>
   </enum>
 
   <enum id="com.github.amezin.ddterm.EllipsizeMode">


### PR DESCRIPTION
Have a single option for panel icon, which toggles ddterm on middle or left click and displays the popup menu on right click. Works with both mouse and touchpad. Although this already "works", I wanted to know your opinion on a few additional changes that I believe could improve this PR.

**1. Have a single class for the panel icon**

To make it possible to have two options of panel icon behavior you wrote a `DDTermPanelIconBase` from which both `DDTermPanelIconPopupMenu` and `DDTermPanelIconToggleButton` inherit. In addition, there's a fourth class `DDTermPanelIconProxy` that instantiates the panel icon according to users' preferences.

If I understood the code correctly, unifying both panel icons should allow us to have a single `DDTermPanelIcon` class that takes care of all that.

**2. Use a toggle instead of multiselect in preferences**

Since there's only one option of panel icon, an on/off switch (boolean) would be more appropriate than the current multiselect (enum). I made a mockup of what it could look like if I also implemented your suggestion of making the icon itself configurable:

![ddterm_preferences_icon_on](https://user-images.githubusercontent.com/65264536/216454637-e059b5ad-5974-4bf9-8ed7-bbc3a57fc778.png)
![ddterm_preferences_icon_off](https://user-images.githubusercontent.com/65264536/216454641-24157a8b-c988-483b-b253-9084a58c2723.png)


