### PR TITLE
panelicon: add option to have both toggle and popup menu

### DIFF
--- a/ddterm/pref/glade/prefs-panel-icon.ui
+++ b/ddterm/pref/glade/prefs-panel-icon.ui
@@ -55,6 +55,7 @@ along with ddterm GNOME Shell extension.  If not, see <http://www.gnu.org/licens
           <item id="none" translatable="yes">None</item>
           <item id="menu-button" translatable="yes">With popup menu</item>
           <item id="toggle-button" translatable="yes">Toggle button</item>
+          <item id="toggle-and-menu-button" translatable="yes">Toggle button and popup menu</item>
         </items>
       </object>
       <packing>

--- a/ddterm/shell/panelicon.js
+++ b/ddterm/shell/panelicon.js
@@ -145,6 +145,69 @@ const PanelIconToggleButton = GObject.registerClass(
     }
 );
 
+const PanelIconToggleAndMenu = GObject.registerClass(
+    class DDTermPanelIconToggleAndMenu extends PanelIconBase {
+        _init() {
+            super._init(false);
+
+            this.toggle_item = new PopupMenu.PopupSwitchMenuItem(
+                translations.gettext('Show'),
+                false
+            );
+            this.menu.addMenuItem(this.toggle_item);
+            this.connections.connect(this.toggle_item, 'toggled', (_, value) => {
+                this.emit('toggle', value);
+            });
+            this.connections.connect(this.toggle_item, 'notify::state', () => {
+                this.notify('active');
+            });
+
+            this.preferences_item = new PopupMenu.PopupMenuItem(
+                translations.gettext('Preferences...')
+            );
+            this.menu.addMenuItem(this.preferences_item);
+            this.connections.connect(this.preferences_item, 'activate', () => {
+                this.emit('open-preferences');
+            });
+        }
+
+        get active() {
+            return this.toggle_item.state;
+        }
+
+        set active(value) {
+            if (value === this.active)
+                return;
+
+            if (value) {
+                this.add_style_pseudo_class('active');
+                this.add_accessible_state(Atk.StateType.CHECKED);
+            } else {
+                this.remove_style_pseudo_class('active');
+                this.remove_accessible_state(Atk.StateType.CHECKED);
+            }
+
+            this.toggle_item.setToggleState(value);
+        }
+
+        static type_name() {
+            return 'toggle-and-menu-button';
+        }
+
+        vfunc_event(event) {
+            if (event.type() === Clutter.EventType.TOUCH_BEGIN ||
+                event.type() === Clutter.EventType.BUTTON_PRESS) {
+                if (event.get_button() === Clutter.BUTTON_PRIMARY ||
+                    event.get_button() === Clutter.BUTTON_MIDDLE)
+                    this.emit('toggle', !this.active);
+                else
+                    super.vfunc_event(event);
+            }
+            return Clutter.EVENT_PROPAGATE;
+        }
+    }
+);
+
 var PanelIconProxy = GObject.registerClass(
     {
         Properties: {
@@ -184,6 +247,7 @@ var PanelIconProxy = GObject.registerClass(
 
             this.types[PanelIconPopupMenu.type_name()] = PanelIconPopupMenu;
             this.types[PanelIconToggleButton.type_name()] = PanelIconToggleButton;
+            this.types[PanelIconToggleAndMenu.type_name()] = PanelIconToggleAndMenu;
         }
 
         get type() {

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ddterm\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:04+0300\n"
+"POT-Creation-Date: 2023-03-06 10:11-0300\n"
 "PO-Revision-Date: 2022-12-20 21:44+0100\n"
 "Last-Translator: FELDMANN arnaud <arnaud.feldmann at gmail dot com>\n"
 "Language-Team: \n"
@@ -170,6 +170,7 @@ msgid "Preferences"
 msgstr "Préférences"
 
 #: ddterm/app/menus.ui:105 ddterm/app/menus.ui:207 ddterm/shell/panelicon.js:85
+#: ddterm/shell/panelicon.js:166
 msgid "Preferences..."
 msgstr "Préférences..."
 
@@ -248,6 +249,26 @@ msgid ""
 msgstr ""
 "Il reste un processus en cours d'exécution dans ce terminal. Fermer ce "
 "terminal va le tuer."
+
+#: ddterm/pref/animation.js:99
+msgid "Animation"
+msgstr "Animation"
+
+#: ddterm/pref/behavior.js:71
+msgid "Behavior"
+msgstr "Comportement"
+
+#: ddterm/pref/colors.js:276
+msgid "Colors"
+msgstr "Couleurs"
+
+#: ddterm/pref/command.js:71
+msgid "Command"
+msgstr "Commande"
+
+#: ddterm/pref/compatibility.js:72
+msgid "Compatibility"
+msgstr "Compatibilité"
 
 #: ddterm/pref/glade/prefs-animation.ui:36
 msgid "Disable"
@@ -792,6 +813,11 @@ msgstr "Avec un menu contextuel"
 msgid "Toggle button"
 msgstr "Bouton de basculement"
 
+#: ddterm/pref/glade/prefs-panel-icon.ui:58
+#, fuzzy
+msgid "Toggle button and popup menu"
+msgstr "Bouton de basculement"
+
 #: ddterm/pref/glade/prefs-position-size.ui:47
 msgid "Window _size:"
 msgstr "Taille de la fenêtre :"
@@ -1170,26 +1196,6 @@ msgstr "Détecter les adresses email"
 msgid "Detect news:/man: URLs"
 msgstr "Détecter les URL de type « news: »"
 
-#: ddterm/pref/animation.js:99
-msgid "Animation"
-msgstr "Animation"
-
-#: ddterm/pref/behavior.js:71
-msgid "Behavior"
-msgstr "Comportement"
-
-#: ddterm/pref/colors.js:276
-msgid "Colors"
-msgstr "Couleurs"
-
-#: ddterm/pref/command.js:71
-msgid "Command"
-msgstr "Commande"
-
-#: ddterm/pref/compatibility.js:72
-msgid "Compatibility"
-msgstr "Compatibilité"
-
 #: ddterm/pref/panelicon.js:57
 msgid "Panel Icon"
 msgstr "Icône de panneau"
@@ -1214,6 +1220,6 @@ msgstr "Onglets"
 msgid "Text"
 msgstr "Texte"
 
-#: ddterm/shell/panelicon.js:73
+#: ddterm/shell/panelicon.js:73 ddterm/shell/panelicon.js:154
 msgid "Show"
 msgstr "Afficher"

--- a/po/fr.po
+++ b/po/fr.po
@@ -814,9 +814,8 @@ msgid "Toggle button"
 msgstr "Bouton de basculement"
 
 #: ddterm/pref/glade/prefs-panel-icon.ui:58
-#, fuzzy
 msgid "Toggle button and popup menu"
-msgstr "Bouton de basculement"
+msgstr ""
 
 #: ddterm/pref/glade/prefs-position-size.ui:47
 msgid "Window _size:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -815,9 +815,8 @@ msgid "Toggle button"
 msgstr "Кнопка переключения"
 
 #: ddterm/pref/glade/prefs-panel-icon.ui:58
-#, fuzzy
 msgid "Toggle button and popup menu"
-msgstr "Кнопка переключения"
+msgstr ""
 
 #: ddterm/pref/glade/prefs-position-size.ui:47
 msgid "Window _size:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ddterm\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:04+0300\n"
+"POT-Creation-Date: 2023-03-06 10:11-0300\n"
 "PO-Revision-Date: 2022-12-21 13:31+0300\n"
 "Last-Translator: vantu5z <vantu5z@mail.ru>\n"
 "Language-Team: Russian <>\n"
@@ -171,6 +171,7 @@ msgid "Preferences"
 msgstr "Параметры"
 
 #: ddterm/app/menus.ui:105 ddterm/app/menus.ui:207 ddterm/shell/panelicon.js:85
+#: ddterm/shell/panelicon.js:166
 msgid "Preferences..."
 msgstr "Параметры..."
 
@@ -249,6 +250,26 @@ msgid ""
 msgstr ""
 "В терминале запущены процессы. При закрытии терминала эти процессы будут "
 "завершены."
+
+#: ddterm/pref/animation.js:99
+msgid "Animation"
+msgstr "Анимация"
+
+#: ddterm/pref/behavior.js:71
+msgid "Behavior"
+msgstr "Поведение"
+
+#: ddterm/pref/colors.js:276
+msgid "Colors"
+msgstr "Цвета"
+
+#: ddterm/pref/command.js:71
+msgid "Command"
+msgstr "Команда"
+
+#: ddterm/pref/compatibility.js:72
+msgid "Compatibility"
+msgstr "Совместимость"
 
 #: ddterm/pref/glade/prefs-animation.ui:36
 msgid "Disable"
@@ -793,6 +814,11 @@ msgstr "С выпадающим меню"
 msgid "Toggle button"
 msgstr "Кнопка переключения"
 
+#: ddterm/pref/glade/prefs-panel-icon.ui:58
+#, fuzzy
+msgid "Toggle button and popup menu"
+msgstr "Кнопка переключения"
+
 #: ddterm/pref/glade/prefs-position-size.ui:47
 msgid "Window _size:"
 msgstr "Размер окна:"
@@ -1173,26 +1199,6 @@ msgstr "Адреса E-mail"
 msgid "Detect news:/man: URLs"
 msgstr "Ссылки вида \"news:/man\""
 
-#: ddterm/pref/animation.js:99
-msgid "Animation"
-msgstr "Анимация"
-
-#: ddterm/pref/behavior.js:71
-msgid "Behavior"
-msgstr "Поведение"
-
-#: ddterm/pref/colors.js:276
-msgid "Colors"
-msgstr "Цвета"
-
-#: ddterm/pref/command.js:71
-msgid "Command"
-msgstr "Команда"
-
-#: ddterm/pref/compatibility.js:72
-msgid "Compatibility"
-msgstr "Совместимость"
-
 #: ddterm/pref/panelicon.js:57
 msgid "Panel Icon"
 msgstr "Значок на панели"
@@ -1217,6 +1223,6 @@ msgstr "Вкладки"
 msgid "Text"
 msgstr "Текст"
 
-#: ddterm/shell/panelicon.js:73
+#: ddterm/shell/panelicon.js:73 ddterm/shell/panelicon.js:154
 msgid "Show"
 msgstr "Показать"

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -136,6 +136,7 @@
     <value nick="none" value="0"/>
     <value nick="menu-button" value="1"/>
     <value nick="toggle-button" value="2"/>
+    <value nick="toggle-and-menu-button" value="3"/>
   </enum>
 
   <enum id="com.github.amezin.ddterm.EllipsizeMode">


### PR DESCRIPTION
As discussed in #328, I added a new panel button that includes the functionality of both previously available options (toggle and popup menu). I tested it using a touchpad and a mouse and it worked well on both cases.

I already ran the CI and it is failing at the step "Ensure translations are up to date", which I'm not sure how to fix 😅.

As usual, thanks for developing `ddterm`! 🚀