### PR TITLE
Disable msgmerge fuzzy matching

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -80,7 +80,7 @@ jobs:
       shell: bash
       if: ${{ always() && steps.checkout.conclusion == 'success' }}
 
-    - name: Ensure translations are up to date
+    - name: Ensure translations are up to date (run `make msgmerge` to fix)
       run: make msgcmp | tee msgcmp.log
       shell: bash
       if: ${{ always() && steps.checkout.conclusion == 'success' }}

--- a/Makefile
+++ b/Makefile
@@ -339,9 +339,10 @@ msgcmp-strict: $(MSGCMP_GOALS)
 all: msgcmp
 
 MSGMERGE_GOALS := $(addprefix msgmerge/, $(LOCALES))
+MSGMERGE_FLAGS := --no-fuzzy-matching --update
 
 $(MSGMERGE_GOALS): msgmerge/%: % $(POT_FILE)
-	msgmerge -U $^
+	msgmerge $(MSGMERGE_FLAGS) $^
 
 msgmerge: $(MSGMERGE_GOALS)
 

--- a/ddterm/pref/glade/prefs-panel-icon.ui
+++ b/ddterm/pref/glade/prefs-panel-icon.ui
@@ -55,6 +55,7 @@ along with ddterm GNOME Shell extension.  If not, see <http://www.gnu.org/licens
           <item id="none" translatable="yes">None</item>
           <item id="menu-button" translatable="yes">With popup menu</item>
           <item id="toggle-button" translatable="yes">Toggle button</item>
+          <item id="toggle-and-menu-button" translatable="yes">Toggle button and popup menu</item>
         </items>
       </object>
       <packing>

--- a/ddterm/shell/panelicon.js
+++ b/ddterm/shell/panelicon.js
@@ -145,6 +145,69 @@ const PanelIconToggleButton = GObject.registerClass(
     }
 );
 
+const PanelIconToggleAndMenu = GObject.registerClass(
+    class DDTermPanelIconToggleAndMenu extends PanelIconBase {
+        _init() {
+            super._init(false);
+
+            this.toggle_item = new PopupMenu.PopupSwitchMenuItem(
+                translations.gettext('Show'),
+                false
+            );
+            this.menu.addMenuItem(this.toggle_item);
+            this.connections.connect(this.toggle_item, 'toggled', (_, value) => {
+                this.emit('toggle', value);
+            });
+            this.connections.connect(this.toggle_item, 'notify::state', () => {
+                this.notify('active');
+            });
+
+            this.preferences_item = new PopupMenu.PopupMenuItem(
+                translations.gettext('Preferences...')
+            );
+            this.menu.addMenuItem(this.preferences_item);
+            this.connections.connect(this.preferences_item, 'activate', () => {
+                this.emit('open-preferences');
+            });
+        }
+
+        get active() {
+            return this.toggle_item.state;
+        }
+
+        set active(value) {
+            if (value === this.active)
+                return;
+
+            if (value) {
+                this.add_style_pseudo_class('active');
+                this.add_accessible_state(Atk.StateType.CHECKED);
+            } else {
+                this.remove_style_pseudo_class('active');
+                this.remove_accessible_state(Atk.StateType.CHECKED);
+            }
+
+            this.toggle_item.setToggleState(value);
+        }
+
+        static type_name() {
+            return 'toggle-and-menu-button';
+        }
+
+        vfunc_event(event) {
+            if (event.type() === Clutter.EventType.TOUCH_BEGIN ||
+                event.type() === Clutter.EventType.BUTTON_PRESS) {
+                if (event.get_button() === Clutter.BUTTON_PRIMARY ||
+                    event.get_button() === Clutter.BUTTON_MIDDLE)
+                    this.emit('toggle', !this.active);
+                else
+                    super.vfunc_event(event);
+            }
+            return Clutter.EVENT_PROPAGATE;
+        }
+    }
+);
+
 var PanelIconProxy = GObject.registerClass(
     {
         Properties: {
@@ -184,6 +247,7 @@ var PanelIconProxy = GObject.registerClass(
 
             this.types[PanelIconPopupMenu.type_name()] = PanelIconPopupMenu;
             this.types[PanelIconToggleButton.type_name()] = PanelIconToggleButton;
+            this.types[PanelIconToggleAndMenu.type_name()] = PanelIconToggleAndMenu;
         }
 
         get type() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -475,9 +475,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-            "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
             "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             },
             "devDependencies": {
                 "eslint": "8.35.0",
-                "eslint-plugin-jsdoc": "40.0.0"
+                "eslint-plugin-jsdoc": "40.0.1"
             }
         },
         "node_modules/@es-joy/jsdoccomment": {
@@ -388,9 +388,9 @@
             }
         },
         "node_modules/eslint-plugin-jsdoc": {
-            "version": "40.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.0.0.tgz",
-            "integrity": "sha512-LOPyIu1vAVvGPkye3ci0moj0iNf3f8bmin6do2DYDj+77NRXWnkmhKRy8swWsatUs3mB5jYPWPUsFg9pyfEiyA==",
+            "version": "40.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.0.1.tgz",
+            "integrity": "sha512-KkiRInury7YrjjV5aCHDxwsPy6XFt5p2b2CnpDMITnWs8patNPf5kj24+VXIWw45kP6z/B0GOKfrYczB56OjQQ==",
             "dev": true,
             "dependencies": {
                 "@es-joy/jsdoccomment": "~0.36.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     },
     "devDependencies": {
         "eslint": "8.35.0",
-        "eslint-plugin-jsdoc": "40.0.0"
+        "eslint-plugin-jsdoc": "40.0.1"
     }
 }

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ddterm\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:04+0300\n"
+"POT-Creation-Date: 2023-03-06 10:11-0300\n"
 "PO-Revision-Date: 2022-12-20 21:44+0100\n"
 "Last-Translator: FELDMANN arnaud <arnaud.feldmann at gmail dot com>\n"
 "Language-Team: \n"
@@ -170,6 +170,7 @@ msgid "Preferences"
 msgstr "Préférences"
 
 #: ddterm/app/menus.ui:105 ddterm/app/menus.ui:207 ddterm/shell/panelicon.js:85
+#: ddterm/shell/panelicon.js:166
 msgid "Preferences..."
 msgstr "Préférences..."
 
@@ -248,6 +249,26 @@ msgid ""
 msgstr ""
 "Il reste un processus en cours d'exécution dans ce terminal. Fermer ce "
 "terminal va le tuer."
+
+#: ddterm/pref/animation.js:99
+msgid "Animation"
+msgstr "Animation"
+
+#: ddterm/pref/behavior.js:71
+msgid "Behavior"
+msgstr "Comportement"
+
+#: ddterm/pref/colors.js:276
+msgid "Colors"
+msgstr "Couleurs"
+
+#: ddterm/pref/command.js:71
+msgid "Command"
+msgstr "Commande"
+
+#: ddterm/pref/compatibility.js:72
+msgid "Compatibility"
+msgstr "Compatibilité"
 
 #: ddterm/pref/glade/prefs-animation.ui:36
 msgid "Disable"
@@ -792,6 +813,10 @@ msgstr "Avec un menu contextuel"
 msgid "Toggle button"
 msgstr "Bouton de basculement"
 
+#: ddterm/pref/glade/prefs-panel-icon.ui:58
+msgid "Toggle button and popup menu"
+msgstr ""
+
 #: ddterm/pref/glade/prefs-position-size.ui:47
 msgid "Window _size:"
 msgstr "Taille de la fenêtre :"
@@ -1170,26 +1195,6 @@ msgstr "Détecter les adresses email"
 msgid "Detect news:/man: URLs"
 msgstr "Détecter les URL de type « news: »"
 
-#: ddterm/pref/animation.js:99
-msgid "Animation"
-msgstr "Animation"
-
-#: ddterm/pref/behavior.js:71
-msgid "Behavior"
-msgstr "Comportement"
-
-#: ddterm/pref/colors.js:276
-msgid "Colors"
-msgstr "Couleurs"
-
-#: ddterm/pref/command.js:71
-msgid "Command"
-msgstr "Commande"
-
-#: ddterm/pref/compatibility.js:72
-msgid "Compatibility"
-msgstr "Compatibilité"
-
 #: ddterm/pref/panelicon.js:57
 msgid "Panel Icon"
 msgstr "Icône de panneau"
@@ -1214,6 +1219,6 @@ msgstr "Onglets"
 msgid "Text"
 msgstr "Texte"
 
-#: ddterm/shell/panelicon.js:73
+#: ddterm/shell/panelicon.js:73 ddterm/shell/panelicon.js:154
 msgid "Show"
 msgstr "Afficher"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ddterm\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-06 10:11-0300\n"
-"PO-Revision-Date: 2022-12-20 21:44+0100\n"
+"POT-Creation-Date: 2023-03-06 21:23+0100\n"
+"PO-Revision-Date: 2023-03-06 21:27+0100\n"
 "Last-Translator: FELDMANN arnaud <arnaud.feldmann at gmail dot com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -13,8 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-"X-Poedit-Basepath: ..\n"
-"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-Basepath: .\n"
 
 #: ddterm/app/appwindow.js:440
 msgid ""
@@ -815,7 +814,7 @@ msgstr "Bouton de basculement"
 
 #: ddterm/pref/glade/prefs-panel-icon.ui:58
 msgid "Toggle button and popup menu"
-msgstr ""
+msgstr "Bouton de basculement et menu contextuel"
 
 #: ddterm/pref/glade/prefs-position-size.ui:47
 msgid "Window _size:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ddterm\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-24 20:04+0300\n"
+"POT-Creation-Date: 2023-03-06 10:11-0300\n"
 "PO-Revision-Date: 2022-12-21 13:31+0300\n"
 "Last-Translator: vantu5z <vantu5z@mail.ru>\n"
 "Language-Team: Russian <>\n"
@@ -171,6 +171,7 @@ msgid "Preferences"
 msgstr "Параметры"
 
 #: ddterm/app/menus.ui:105 ddterm/app/menus.ui:207 ddterm/shell/panelicon.js:85
+#: ddterm/shell/panelicon.js:166
 msgid "Preferences..."
 msgstr "Параметры..."
 
@@ -249,6 +250,26 @@ msgid ""
 msgstr ""
 "В терминале запущены процессы. При закрытии терминала эти процессы будут "
 "завершены."
+
+#: ddterm/pref/animation.js:99
+msgid "Animation"
+msgstr "Анимация"
+
+#: ddterm/pref/behavior.js:71
+msgid "Behavior"
+msgstr "Поведение"
+
+#: ddterm/pref/colors.js:276
+msgid "Colors"
+msgstr "Цвета"
+
+#: ddterm/pref/command.js:71
+msgid "Command"
+msgstr "Команда"
+
+#: ddterm/pref/compatibility.js:72
+msgid "Compatibility"
+msgstr "Совместимость"
 
 #: ddterm/pref/glade/prefs-animation.ui:36
 msgid "Disable"
@@ -793,6 +814,10 @@ msgstr "С выпадающим меню"
 msgid "Toggle button"
 msgstr "Кнопка переключения"
 
+#: ddterm/pref/glade/prefs-panel-icon.ui:58
+msgid "Toggle button and popup menu"
+msgstr ""
+
 #: ddterm/pref/glade/prefs-position-size.ui:47
 msgid "Window _size:"
 msgstr "Размер окна:"
@@ -1173,26 +1198,6 @@ msgstr "Адреса E-mail"
 msgid "Detect news:/man: URLs"
 msgstr "Ссылки вида \"news:/man\""
 
-#: ddterm/pref/animation.js:99
-msgid "Animation"
-msgstr "Анимация"
-
-#: ddterm/pref/behavior.js:71
-msgid "Behavior"
-msgstr "Поведение"
-
-#: ddterm/pref/colors.js:276
-msgid "Colors"
-msgstr "Цвета"
-
-#: ddterm/pref/command.js:71
-msgid "Command"
-msgstr "Команда"
-
-#: ddterm/pref/compatibility.js:72
-msgid "Compatibility"
-msgstr "Совместимость"
-
 #: ddterm/pref/panelicon.js:57
 msgid "Panel Icon"
 msgstr "Значок на панели"
@@ -1217,6 +1222,6 @@ msgstr "Вкладки"
 msgid "Text"
 msgstr "Текст"
 
-#: ddterm/shell/panelicon.js:73
+#: ddterm/shell/panelicon.js:73 ddterm/shell/panelicon.js:154
 msgid "Show"
 msgstr "Показать"

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -164,7 +164,7 @@
       <default>''</default>
     </key>
     <key name="panel-icon-type" enum="com.github.amezin.ddterm.PanelIconType">
-      <default>'menu-button'</default>
+      <default>'toggle-and-menu-button'</default>
     </key>
     <key name="theme-variant" enum="com.github.amezin.ddterm.ThemeVariant">
       <default>'system'</default>

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -136,6 +136,7 @@
     <value nick="none" value="0"/>
     <value nick="menu-button" value="1"/>
     <value nick="toggle-button" value="2"/>
+    <value nick="toggle-and-menu-button" value="3"/>
   </enum>
 
   <enum id="com.github.amezin.ddterm.EllipsizeMode">

--- a/test/compose.yaml
+++ b/test/compose.yaml
@@ -5,25 +5,25 @@
 
 services:
   debian-11:
-    image: ghcr.io/ddterm/gnome-shell-pod/debian-11:2023.03.03.1
+    image: ghcr.io/ddterm/gnome-shell-pod/debian-11:2023.03.07.0
 
   fedora-36:
-    image: ghcr.io/ddterm/gnome-shell-pod/fedora-36:2023.03.03.1
+    image: ghcr.io/ddterm/gnome-shell-pod/fedora-36:2023.03.07.0
 
   fedora-37:
-    image: ghcr.io/ddterm/gnome-shell-pod/fedora-37:2023.03.03.1
+    image: ghcr.io/ddterm/gnome-shell-pod/fedora-37:2023.03.07.0
 
   ubuntu-20.04:
-    image: ghcr.io/ddterm/gnome-shell-pod/ubuntu-20.04:2023.03.03.1
+    image: ghcr.io/ddterm/gnome-shell-pod/ubuntu-20.04:2023.03.07.0
 
   ubuntu-22.04:
-    image: ghcr.io/ddterm/gnome-shell-pod/ubuntu-22.04:2023.03.03.1
+    image: ghcr.io/ddterm/gnome-shell-pod/ubuntu-22.04:2023.03.07.0
 
   ubuntu-22.10:
-    image: ghcr.io/ddterm/gnome-shell-pod/ubuntu-22.10:2023.03.03.1
+    image: ghcr.io/ddterm/gnome-shell-pod/ubuntu-22.10:2023.03.07.0
 
   centos-9:
-    image: ghcr.io/ddterm/gnome-shell-pod/centos-9:2023.03.03.1
+    image: ghcr.io/ddterm/gnome-shell-pod/centos-9:2023.03.07.0
 
   archlinux:
-    image: ghcr.io/ddterm/gnome-shell-pod/archlinux:2023.03.03.1
+    image: ghcr.io/ddterm/gnome-shell-pod/archlinux:2023.03.07.0


### PR DESCRIPTION
Create the variable `MSGMERGE_FLAGS` and add the flag `--no-fuzzy-matching` to it, so only exact matches are used when updating the .po files. Also move the `-U` flag to the same variable, using its non-abbreviated form `--update` for improved clarity.