### PR TITLE
translations: disable msgmerge fuzzy matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,9 +339,10 @@ msgcmp-strict: $(MSGCMP_GOALS)
 all: msgcmp
 
 MSGMERGE_GOALS := $(addprefix msgmerge/, $(LOCALES))
+MSGMERGE_FLAGS := --no-fuzzy-matching --update
 
 $(MSGMERGE_GOALS): msgmerge/%: % $(POT_FILE)
-	msgmerge -U $^
+	msgmerge $(MSGMERGE_FLAGS) $^
 
 msgmerge: $(MSGMERGE_GOALS)
 

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,9 @@ $(MSGMERGE_GOALS): msgmerge/%: % $(POT_FILE)
 
 msgmerge: $(MSGMERGE_GOALS)
 
+msgmerge-fuzzy: MSGMERGE_FLAGS := --update
+msgmerge-fuzzy: $(MSGMERGE_GOALS)
+
 .PHONY: msgmerge $(MSGMERGE_GOALS)
 
 # ESLint


### PR DESCRIPTION
Create the variable `MSGMERGE_FLAGS` and add the flag `--no-fuzzy-matching` to it, so only exact matches are used when updating the .po files. Also move the `-U` flag to the same variable, using its non-abbreviated form `--update` for improved clarity.