### PR TITLE
metadata.json: add support for GNOME 44

### DIFF
--- a/metadata.json.in
+++ b/metadata.json.in
@@ -11,7 +11,7 @@
     "41",
     "42",
     "43",
-    "44.beta"
+    "44"
   ],
   "version": 44,
   "url": "https://github.com/ddterm/gnome-shell-extension-ddterm"


### PR DESCRIPTION
I've been using a locally built version of ddterm on GNOME 44 for a few days without any issues. From commit 4c66de2a194690ff49087ee58c373e1b23516f1f, it looks like you already made sure it is compatible with the latest version of the desktop environment.

I added the "44" tag to the `metadata.json` file. I also removed the "44.beta" tag, since it is obsolete now officially that 44 was officially release.