### PR TITLE
Fix custom-command setting

### DIFF
--- a/ddterm/app/terminalpage.js
+++ b/ddterm/app/terminalpage.js
@@ -698,8 +698,10 @@ var TerminalPage = GObject.registerClass(
             const command_type = this.settings.get_string('command');
 
             if (command_type === 'custom-command') {
+                const command = this.settings.get_string('custom-command');
+
                 let _;
-                [_, argv] = GLib.shell_parse_argv(this.settings['custom-command'].value);
+                [_, argv] = GLib.shell_parse_argv(command);
 
                 spawn_flags = GLib.SpawnFlags.SEARCH_PATH_FROM_ENVP;
             } else {


### PR DESCRIPTION
When trying to run the master version of this extension, I encountered the same issue mentioned in [this comment](https://github.com/ddterm/gnome-shell-extension-ddterm/issues/443#issuecomment-1543526683). Looking at the git blame, this seems to be a leftover from removing rxjs.