### PR TITLE
Makefile: Expand wildcard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ PACK_CONTENT += $(EXECUTABLES) $(filter-out $(EXECUTABLES),$(JS_SOURCES))
 PACK_CONTENT += \
 	ddterm/app/style.css \
 	ddterm/app/dependencies.json \
-	ddterm/app/icons/* \
+	$(wildcard ddterm/app/icons/*) \
 	ddterm/com.github.amezin.ddterm.Extension.xml \
 	ddterm/com.github.amezin.ddterm.desktop.in \
 	ddterm/com.github.amezin.ddterm.service.in \


### PR DESCRIPTION
Without this patch build fails with following error:

```
make: *** No rule to make target 'ddterm/app/icons/*', needed by '.../ddterm@amezin.github.com/ddterm/app/icons/*'.  Stop.
```