### PR TITLE
extension: expose Hide action in D-Bus API

### DIFF
--- a/ddterm/com.github.amezin.ddterm.Extension.xml
+++ b/ddterm/com.github.amezin.ddterm.Extension.xml
@@ -5,6 +5,7 @@
     <interface name="com.github.amezin.ddterm.Extension">
         <method name="Toggle"/>
         <method name="Activate"/>
+        <method name="Hide"/>
         <method name="Service"/>
         <method name="GetTargetRect">
             <arg type="i" name="x" direction="out"/>

--- a/ddterm/shell/dbusapi.js
+++ b/ddterm/shell/dbusapi.js
@@ -92,6 +92,10 @@ var Api = GObject.registerClass({
             return_type: GObject.TYPE_JSOBJECT,
             accumulator: GObject.AccumulatorType.FIRST_WINS,
         },
+        'hide': {
+            return_type: GObject.TYPE_JSOBJECT,
+            accumulator: GObject.AccumulatorType.FIRST_WINS,
+        },
         'service': {
             return_type: GObject.TYPE_JSOBJECT,
             accumulator: GObject.AccumulatorType.FIRST_WINS,
@@ -117,6 +121,10 @@ var Api = GObject.registerClass({
 
     ActivateAsync(params, invocation) {
         handle_dbus_method_call_async(() => this.emit('activate'), params, invocation);
+    }
+
+    HideAsync(params, invocation) {
+        handle_dbus_method_call_async(() => this.emit('hide'), params, invocation);
     }
 
     ServiceAsync(params, invocation) {

--- a/ddterm/shell/extension.js
+++ b/ddterm/shell/extension.js
@@ -126,6 +126,7 @@ function create_dbus_interface(window_manager, app_control, rollback) {
 
     dbus_interface.connect('toggle', () => app_control.toggle());
     dbus_interface.connect('activate', () => app_control.activate());
+    dbus_interface.connect('hide', () => app_control.hide());
     dbus_interface.connect('service', () => app_control.ensure_running());
     dbus_interface.connect('refresh-target-rect', () => {
         /*


### PR DESCRIPTION
I have some scripts that I mostly only run from the dropdown terminal, and I like them to be able to close the dropdown automatically when they finish. `Toggle` works, but on the rare occasions when I run these scripts from other terminals, I don't want it to _open_ the dropdown. Using `Activate` then `Toggle` is a workaround, but it causes the terminal to flicker when the dropdown is not already active.

This PR exposes the idempotent `Hide` action over the D-Bus API. I think I hit all the spots where the code needed to be updated -- I just grepped `toggle` and `activate` and looked for all the spots where it looked like I needed to wire things up. Apologies if I missed anything; I haven't fully wrapped my head around the extension architecture, so this is mostly a copy-paste job.

I wrote this against the v46 tag because I'm running GNOME shell 42.9 (on `jammy`), but it merges fine against master as well. Tested manually on my machine with:

```
gdbus call --session --dest=org.gnome.Shell --object-path /org/gnome/Shell/Extensions/ddterm --method com.github.amezin.ddterm.Extension.Hide
```

which seems to work the same way as `.Activate`. I don't see anything breaking if I call it when the terminal is already hidden.