### PR TITLE
extension/wm: try to improve window positioning and resizing

### DIFF
--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -657,6 +657,7 @@ class CommonTests(ddterm_fixtures.DDTermFixtures):
             window_size == 1.0 and initially_maximized,
             window_pos2,
             monitor,
+            3,
         ) as wait:
             test_api.settings.set_string('window-position', window_pos2)
             wait()


### PR DESCRIPTION
It seems to work better, windows aren't flying from one monitor to another anymore.

Tested on bare-metal GNOME 46 (Arch), Debian 12 VM.

I had only one monitor for a long time, so I didn't notice how broken it is.

https://github.com/ddterm/gnome-shell-extension-ddterm/issues/405