### PR TITLE
app/terminal: use `TERMPROP_CURRENT_DIRECTORY_URI` when available

### DIFF
--- a/ddterm/app/terminal.js
+++ b/ddterm/app/terminal.js
@@ -507,7 +507,9 @@ export const Terminal = GObject.registerClass({
     }
 
     get_cwd() {
-        const uri = this.current_directory_uri;
+        const uri = this.ref_termprop_uri_by_id
+            ? this.ref_termprop_uri_by_id(Vte.TERMPROP_CURRENT_DIRECTORY_URI)?.to_string()
+            : this.current_directory_uri;
 
         if (uri)
             return Gio.File.new_for_uri(uri);


### PR DESCRIPTION
Fixes https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1037