### PR TITLE
translations: fix copyright notices

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Czech translation for ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
 # This file is distributed under the same license as the ddterm package.
 # Pavel Novák <pavelnov32@gmail.com>, 2023.
 msgid ""

--- a/po/de.po
+++ b/po/de.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# German translation of ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
 # This file is distributed under the same license as the ddterm package.
 #
 # Jörn Weigend <das.jott@gmail.com>, 2023.

--- a/po/el.po
+++ b/po/el.po
@@ -1,3 +1,6 @@
+# Greek translation for ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
+# This file is distributed under the same license as the ddterm package.
 # Anagnostakis Ioannis <rizitis@gmail.com>, 2023.
 #
 msgid ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the ddterm@amezin.github.com package.
+# Esperanto translation for ddterm
+# Copyright (C) 2024 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
+# This file is distributed under the same license as the ddterm package.
 # phlostically <phlostically@mailinator.com>, 2024.
 msgid ""
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Spanish translation for ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
 # This file is distributed under the same license as the ddterm package.
 # Adrian Alberdi Ainciburu <adrian1992@gmail.com>, 2023.
 # gallegonovato <fran-carro@hotmail.es>, 2023, 2024.

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,5 +1,7 @@
+# French translation for ddterm
+# Copyright (C) 2022 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
+# This file is distributed under the same license as the ddterm package.
 # Arnaud Feldmann <arnaud.feldmann@gmail.com>, 2023, 2024.
-# Aleksandr Mezin <mezin.alexander@gmail.com>, 2023.
 # fail a fail <yassadmi@proton.me>, 2023.
 # Stephane LE CAER <stephane@slc66.net>, 2023.
 # Patricio Carrau <duckycb@proton.me>, 2024.

--- a/po/it.po
+++ b/po/it.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Italian translation for ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
 # This file is distributed under the same license as the ddterm package.
 # Matteo Cerri <mttcerri@hotmail.com>, 2023.
 # Frankie McEyes <mceyes@protonmail.com>, 2023.

--- a/po/meson.build
+++ b/po/meson.build
@@ -5,6 +5,7 @@ gettext_args = [
   '--check=space-ellipsis',
   '--check=bullet-unicode',
   # TODO: '--check=quote-unicode',
+  '--copyright-holder=ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>',
 ]
 
 gettext_targets = i18n.gettext(

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Norwegian Bokmål translation for ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
 # This file is distributed under the same license as the ddterm package.
 # Allan Nordhøy <epost@anotheragency.no>, 2023, 2024.
 msgid ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Polish translation for ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
 # This file is distributed under the same license as the ddterm package.
 # Michał Olejniczak <blind.x6@gmail.com>, 2023.
 # Eryk Michalak <gnu.ewm@protonmail.com>, 2023.

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Portuguese translation for ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
 # This file is distributed under the same license as the ddterm package.
 # Cezar Cruz <cezarcruz@outlook.com>, 2023.
 # Luiz Carlos de Souza Santos <lcdessantos@gmail.com>, 2023.

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,3 +1,6 @@
+# Russian translation for ddterm
+# Copyright (C) 2022 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
+# This file is distributed under the same license as the ddterm package.
 # vantu5z <vantu5z@mail.ru>, 2022-2023.
 # Aleksandr Mezin <mezin.alexander@gmail.com>, 2023, 2024.
 # Ivan Vantu5z <vantu5z@mail.ru>, 2023.

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the ddterm@amezin.github.com package.
+# Turkish translation for ddterm
+# Copyright (C) 2024 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
+# This file is distributed under the same license as the ddterm package.
 # Mustafa Kemal Gilor <mustafa.gilor@canonical.com>, 2024.
 # Muha Aliss <muhaaliss@users.noreply.hosted.weblate.org>, 2024.
 msgid ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Chinese translation for ddterm
+# Copyright (C) 2023 ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
 # This file is distributed under the same license as the ddterm package.
 # yuh <yuhldr@qq.com>, 2023, 2024.
 msgid ""


### PR DESCRIPTION
Currently, translation files either contain a placeholder:

    Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER

or no explicit copyright notice at all. I'm trying to make the repository compliant with https://reuse.software/ - it requires explicit per-file copyright notices everywhere.

This PR replaces the placeholder with

    Copyright (C) <year of file creation> ddterm contributors

And adds the notice where it's missing. .pot file will be fixed automatically by CI.

On one hand, this doesn't change the license, and all possible copyright holders are still included. On the other hand, to be completely safe I should likely ask all contributors for permission - but it's not feasible, some people just don't respond. So I decided to ask at least those who joined the organization.