### PR TITLE
fix: remove blank spacing from panel icons

### DIFF
--- a/ddterm/shell/panelicon.js
+++ b/ddterm/shell/panelicon.js
@@ -47,7 +47,7 @@ const PanelIconBase = GObject.registerClass({
 
         this.add_child(new St.Icon({
             icon_name: 'utilities-terminal',
-            style_class: 'system-status-icon',
+            style_class: 'system-status-icon indicator-icon',
         }));
     }
 });

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,3 +1,8 @@
 #ddterm-panel-icon > StIcon {
     -st-icon-style: symbolic;
 }
+
+.indicator-icon {
+  padding: 0px;
+  margin: 0px;
+}


### PR DESCRIPTION
version|pic
-|-
old|![截图 2024-12-13 19-48-01](https://github.com/user-attachments/assets/aaf3252d-1553-4f78-83de-b44d182d4628)
new|![截图 2024-12-13 19-47-13](https://github.com/user-attachments/assets/dc02cb08-6d7c-47ca-ae5c-2c07fbd9c792)
