### PR TITLE
Add option to keep previous session as a backup

### DIFF
--- a/ddterm/app/application.js
+++ b/ddterm/app/application.js
@@ -662,7 +662,8 @@ class Application extends Gtk.Application {
             this.ensure_window().deserialize_state(data_variant);
         }
 
-        GLib.unlink(this.session_file_path);
+        if (!this.settings.get_boolean('keep-session-backup'))
+            GLib.unlink(this.session_file_path);
     }
 
     save_session() {

--- a/ddterm/pref/behavior.js
+++ b/ddterm/pref/behavior.js
@@ -39,6 +39,7 @@ export const BehaviorWidget = GObject.registerClass({
             'hide-window-on-esc',
             'pointer-autohide',
             'force-x11-gdk-backend',
+            'keep-session-backup',
         ]);
     }
 

--- a/ddterm/pref/ui/prefs-behavior.ui
+++ b/ddterm/pref/ui/prefs-behavior.ui
@@ -147,5 +147,21 @@ You'll have to close all tabs for this option to take effect.</property>
         <property name="width">2</property>
       </packing>
     </child>
+    <child>
+      <object class="GtkCheckButton" id="keep_session_backup_check">
+        <property name="label" translatable="yes">_Keep previous session as backup</property>
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
+        <property name="action-name">settings.keep-session-backup</property>
+        <property name="use-underline">True</property>
+        <property name="draw-indicator">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">8</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
   </template>
 </interface>

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -179,6 +179,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <key name="force-x11-gdk-backend" type="b">
       <default>false</default>
     </key>
+    <key name="keep-session-backup" type="b">
+      <default>false</default>
+    </key>
     <key name="window-resizable" type="b">
       <default>true</default>
     </key>

--- a/tests/dbus-interfaces/com.github.amezin.ddterm.Settings.xml
+++ b/tests/dbus-interfaces/com.github.amezin.ddterm.Settings.xml
@@ -22,6 +22,7 @@
         <property type="b" name="hide-when-focus-lost" access="readwrite"/>
         <property type="b" name="window-stick" access="readwrite"/>
         <property type="b" name="window-skip-taskbar" access="readwrite"/>
+        <property type="b" name="keep-session-backup" access="readwrite"/>
         <property type="s" name="theme-variant" access="readwrite"/>
         <method name="Destroy"/>
     </interface>


### PR DESCRIPTION
When enabled, this helps to prevent loosing the session in case of an unexpected OS/app crash. I have many pre-configured tabs, that I already lost many times and I always have to set them up again, which is cumbersome.

I added it as an option to not modify the current (intentional?) behavior. Of course we could also just simply remove the line `GLib.unlink(this.session_file_path);`.