### PR TITLE
app: don't remove session file after loading it

### DIFF
--- a/ddterm/app/application.js
+++ b/ddterm/app/application.js
@@ -655,14 +655,14 @@ class Application extends Gtk.Application {
                 );
 
                 if (!data_variant.is_normal_form())
-                    throw new Error('Invalid session file data variant, delete session file.');
+                    throw new Error('Session data is malformed, probably the file was damaged');
 
                 this.ensure_window().deserialize_state(data_variant);
             }
         } catch (ex) {
             if (!(ex instanceof GLib.Error &&
                 ex.matches(GLib.file_error_quark(), GLib.FileError.NOENT))) {
-                logError(ex, "Can't restore session, delete session file.");
+                logError(ex, "Can't restore session. Deleting session file.");
                 GLib.unlink(this.session_file_path);
             }
         }

--- a/ddterm/app/application.js
+++ b/ddterm/app/application.js
@@ -647,18 +647,19 @@ class Application extends Gtk.Application {
         try {
             const [, data] = GLib.file_get_contents(this.session_file_path);
 
-            if (data?.length) {
-                const data_variant = GLib.Variant.new_from_bytes(
-                    new GLib.VariantType('a{sv}'),
-                    data,
-                    false
-                );
+            if (!data?.length)
+                return;
 
-                if (!data_variant.is_normal_form())
-                    throw new Error('Session data is malformed, probably the file was damaged');
+            const data_variant = GLib.Variant.new_from_bytes(
+                new GLib.VariantType('a{sv}'),
+                data,
+                false
+            );
 
-                this.ensure_window().deserialize_state(data_variant);
-            }
+            if (!data_variant.is_normal_form())
+                throw new Error('Session data is malformed, probably the file was damaged');
+
+            this.ensure_window().deserialize_state(data_variant);
         } catch (ex) {
             if (!(ex instanceof GLib.Error &&
                 ex.matches(GLib.file_error_quark(), GLib.FileError.NOENT))) {

--- a/ddterm/app/application.js
+++ b/ddterm/app/application.js
@@ -552,10 +552,6 @@ class Application extends Gtk.Application {
             display_config: this.display_config,
         });
 
-        this.window.connect('close', () => {
-            this.save_session();
-        });
-
         this.window.connect('destroy', source => {
             if (source === this.window)
                 this.window = null;
@@ -663,7 +659,16 @@ class Application extends Gtk.Application {
                 false
             );
 
+            if (!data_variant.is_normal_form()) {
+                logError(new Error('Invalid session file data variant, delete session file.'));
+                GLib.unlink(this.session_file_path);
+                return;
+            }
+
             this.ensure_window().deserialize_state(data_variant);
+        } else {
+            logError(new Error('Invalid session file data, delete session file.'));
+            GLib.unlink(this.session_file_path);
         }
     }
 

--- a/ddterm/app/appwindow.js
+++ b/ddterm/app/appwindow.js
@@ -135,6 +135,9 @@ export const AppWindow = GObject.registerClass({
             'no-split'
         ),
     },
+    Signals: {
+        'close': {},
+    },
 },
 class DDTermAppWindow extends Gtk.ApplicationWindow {
     _init(params) {
@@ -333,8 +336,10 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
         this.update_show_shortcuts();
 
         this.connect('notify::is-empty', () => {
-            if (this.is_empty)
+            if (this.is_empty) {
+                this.emit('close');
                 this.close();
+            }
         });
 
         this._hide_on_close();

--- a/ddterm/app/appwindow.js
+++ b/ddterm/app/appwindow.js
@@ -135,9 +135,6 @@ export const AppWindow = GObject.registerClass({
             'no-split'
         ),
     },
-    Signals: {
-        'close': {},
-    },
 },
 class DDTermAppWindow extends Gtk.ApplicationWindow {
     _init(params) {
@@ -337,7 +334,7 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
 
         this.connect('notify::is-empty', () => {
             if (this.is_empty) {
-                this.emit('close');
+                this.application.save_session();
                 this.close();
             }
         });


### PR DESCRIPTION
Do not delete the session file after successfully restoring it. This has the benefit that we do not loose the session in case of a OS/app crash.

Delete the session file if all tabs are closed (windows destroyed).

Delete the session file in case something goes wrong during restoring the session.

I actually could not make the session restore to fail, if I modified a session file it would just not load it and start with a new tab. But it did not throw  any errors or so, which would delete the file. But I guess it cannot hurt to have that in place anyway.