### PR TITLE
[WIP] Gtk4 port

### DIFF
--- a/ddterm/app/accellabel.js
+++ b/ddterm/app/accellabel.js
@@ -29,7 +29,7 @@ class DDTermAccelLabel extends Gtk.Label {
 
     #realize() {
         this.#hierarchy_handler =
-            this.connect('hierarchy-changed', this.#update_hierarchy.bind(this));
+            this.connect('notify::root', this.#update_hierarchy.bind(this));
 
         this.#update_hierarchy();
     }
@@ -97,7 +97,7 @@ class DDTermAccelLabel extends Gtk.Label {
             this.#keys_handler = null;
         }
 
-        this.#toplevel = this.get_toplevel();
+        this.#toplevel = this.root;
 
         if (this.#toplevel instanceof Gtk.Window) {
             this.#keys_handler =
@@ -119,7 +119,10 @@ class DDTermAccelLabel extends Gtk.Label {
 
         for (const shortcut of toplevel.application?.get_accels_for_action(action) || []) {
             try {
-                return Gtk.accelerator_get_label(...Gtk.accelerator_parse(shortcut));
+                const [ok, key, mods] = Gtk.accelerator_parse(shortcut);
+
+                if (ok)
+                    return Gtk.accelerator_get_label(key, mods);
             } catch (ex) {
                 logError(ex);
             }

--- a/ddterm/app/application.js
+++ b/ddterm/app/application.js
@@ -9,7 +9,7 @@ import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 import Gdk from 'gi://Gdk';
 import Gtk from 'gi://Gtk';
-import Handy from 'gi://Handy';
+import Adw from 'gi://Adw';
 
 import Gettext from 'gettext';
 import System from 'system';
@@ -61,7 +61,7 @@ export const Application = GObject.registerClass({
         ),
     },
 },
-class Application extends Gtk.Application {
+class Application extends Adw.Application {
     _init(params) {
         super._init(params);
 
@@ -244,9 +244,6 @@ class Application extends Gtk.Application {
             this.add_action(this.settings.create_action(key));
         });
 
-        Handy.init();
-        this.style_manager = Handy.StyleManager.get_default();
-
         this.settings.connect(
             'changed::theme-variant',
             this.update_color_scheme.bind(this)
@@ -257,8 +254,8 @@ class Application extends Gtk.Application {
         const css_provider = Gtk.CssProvider.new();
         css_provider.load_from_file(get_resource_file('style.css'));
 
-        Gtk.StyleContext.add_provider_for_screen(
-            Gdk.Screen.get_default(),
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
             css_provider,
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         );
@@ -336,7 +333,8 @@ class Application extends Gtk.Application {
             this.bind_shortcut(action, key);
         });
 
-        Gtk.IconTheme.get_default().append_search_path(get_resource_file('icons').get_path());
+        const icon_theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
+        icon_theme.add_search_path(get_resource_file('icons').get_path());
 
         this.session_file_path = GLib.build_filenamev([
             GLib.get_user_cache_dir(),
@@ -544,6 +542,7 @@ class Application extends Gtk.Application {
             terminal_settings: this.terminal_settings,
             extension_dbus: this.extension_dbus,
             display_config: this.display_config,
+            hide_on_close: true,
         });
 
         this.window.connect('destroy', source => {
@@ -581,7 +580,7 @@ class Application extends Gtk.Application {
                 application: this,
             });
 
-            this.prefs_dialog.connect('destroy', source => {
+            this.prefs_dialog.connect('close-request', source => {
                 if (source === this.prefs_dialog)
                     this.prefs_dialog = null;
             });
@@ -629,9 +628,9 @@ class Application extends Gtk.Application {
 
     update_color_scheme() {
         const mapping = {
-            'system': Handy.ColorScheme.PREFER_LIGHT,
-            'dark': Handy.ColorScheme.FORCE_DARK,
-            'light': Handy.ColorScheme.FORCE_LIGHT,
+            'system': Adw.ColorScheme.DEFAULT,
+            'dark': Adw.ColorScheme.FORCE_DARK,
+            'light': Adw.ColorScheme.FORCE_LIGHT,
         };
 
         const variant = this.settings.get_string('theme-variant');

--- a/ddterm/app/appwindow.js
+++ b/ddterm/app/appwindow.js
@@ -16,33 +16,28 @@ import { get_resource_file } from './resources.js';
 import { DisplayConfig, LayoutMode } from '../util/displayconfig.js';
 
 function make_resizer(orientation) {
-    const box = new Gtk.EventBox({ visible: true });
-
-    new Gtk.Separator({
+    const box = new Gtk.Separator({
         visible: true,
         orientation,
-        parent: box,
         margin_top: orientation === Gtk.Orientation.HORIZONTAL ? 2 : 0,
         margin_bottom: orientation === Gtk.Orientation.HORIZONTAL ? 2 : 0,
         margin_start: orientation === Gtk.Orientation.VERTICAL ? 2 : 0,
         margin_end: orientation === Gtk.Orientation.VERTICAL ? 2 : 0,
     });
 
-    box.connect('realize', () => {
-        box.window.cursor = Gdk.Cursor.new_from_name(
-            box.get_display(),
-            orientation === Gtk.Orientation.VERTICAL ? 'ew-resize' : 'ns-resize'
-        );
-    });
+    box.cursor = Gdk.Cursor.new_from_name(
+        orientation === Gtk.Orientation.VERTICAL ? 'ew-resize' : 'ns-resize',
+        null
+    );
 
     return box;
 }
 
 const WINDOW_POS_TO_RESIZE_EDGE = {
-    top: Gdk.WindowEdge.SOUTH,
-    bottom: Gdk.WindowEdge.NORTH,
-    left: Gdk.WindowEdge.EAST,
-    right: Gdk.WindowEdge.WEST,
+    top: Gdk.SurfaceEdge.SOUTH,
+    bottom: Gdk.SurfaceEdge.NORTH,
+    left: Gdk.SurfaceEdge.EAST,
+    right: Gdk.SurfaceEdge.WEST,
 };
 
 export const AppWindow = GObject.registerClass({
@@ -87,8 +82,8 @@ export const AppWindow = GObject.registerClass({
             '',
             '',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.EXPLICIT_NOTIFY,
-            Gdk.WindowEdge,
-            Gdk.WindowEdge.SOUTH
+            Gdk.SurfaceEdge,
+            Gdk.SurfaceEdge.SOUTH
         ),
         'tab-label-width': GObject.ParamSpec.double(
             'tab-label-width',
@@ -135,36 +130,43 @@ export const AppWindow = GObject.registerClass({
             'no-split'
         ),
     },
+    Signals: {
+        'size-allocate': {
+            param_types: [GObject.TYPE_INT, GObject.TYPE_INT],
+        },
+    },
 },
 class DDTermAppWindow extends Gtk.ApplicationWindow {
     _init(params) {
         super._init({
             title: Gettext.gettext('ddterm'),
             icon_name: 'utilities-terminal',
-            window_position: Gtk.WindowPosition.CENTER,
             ...params,
         });
 
         this.menus =
             Gtk.Builder.new_from_file(get_resource_file('./ui/menus.ui').get_path());
 
-        const grid = new Gtk.Grid({
-            parent: this,
-            visible: true,
-        });
+        const grid = new Gtk.Grid({ visible: true });
+
+        this.set_child(grid);
 
         this.paned = new Gtk.Paned({
             visible: true,
-            border_width: 0,
             hexpand: true,
             vexpand: true,
+            shrink_start_child: false,
+            shrink_end_child: false,
         });
         grid.attach(this.paned, 1, 1, 1, 1);
 
         let window_title_binding = null;
-        this.paned.connect('set-focus-child', (paned, child) => {
+        this.connect('notify::focus-widget', () => {
+            if (window_title_binding?.source === this.active_notebook)
+                return;
+
             window_title_binding?.unbind();
-            window_title_binding = child?.bind_property(
+            window_title_binding = this.active_notebook?.bind_property(
                 'current-title',
                 this,
                 'title',
@@ -175,11 +177,11 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
         });
 
         const notebook1 = this.create_notebook();
-        this.paned.pack1(notebook1, true, false);
+        this.paned.set_start_child(notebook1);
         this.paned.set_focus_child(notebook1);
 
         const notebook2 = this.create_notebook();
-        this.paned.pack2(notebook2, true, false);
+        this.paned.set_end_child(notebook2);
 
         this.paned.connect('notify::orientation', () => this.notify('split-layout'));
         this.connect('notify::is-split', () => this.notify('split-layout'));
@@ -189,7 +191,7 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             this.freeze_notify();
 
             try {
-                src.remove(child);
+                src.remove_page(src.page_num(child));
                 dst.insert_page(child, label, -1);
             } finally {
                 this.thaw_notify();
@@ -200,7 +202,9 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
         notebook2.connect('move-to-other-pane', (_, page) => move_page(page, notebook2, notebook1));
 
         this.connect('notify::tab-label-width', this.update_tab_label_width.bind(this));
-        this.connect('configure-event', this.update_tab_label_width.bind(this));
+        this.connect('realize', () => {
+            this.get_surface().connect('notify::width', this.update_tab_label_width.bind(this));
+        });
         this.update_tab_label_width();
 
         this.settings.bind(
@@ -212,7 +216,11 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
 
         const add_resize_box = (edge, x, y, orientation) => {
             const box = make_resizer(orientation);
-            box.connect('button-press-event', this.start_resizing.bind(this, edge));
+            const gesture = Gtk.GestureClick.new();
+
+            gesture.set_button(Gdk.BUTTON_PRIMARY);
+            gesture.connect('pressed', this.start_resizing.bind(this, edge));
+            box.add_controller(gesture);
             grid.attach(box, x, y, 1, 1);
 
             const update_visible = () => {
@@ -224,10 +232,10 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             update_visible();
         };
 
-        add_resize_box(Gdk.WindowEdge.SOUTH, 1, 2, Gtk.Orientation.HORIZONTAL);
-        add_resize_box(Gdk.WindowEdge.NORTH, 1, 0, Gtk.Orientation.HORIZONTAL);
-        add_resize_box(Gdk.WindowEdge.EAST, 2, 1, Gtk.Orientation.VERTICAL);
-        add_resize_box(Gdk.WindowEdge.WEST, 0, 1, Gtk.Orientation.VERTICAL);
+        add_resize_box(Gdk.SurfaceEdge.SOUTH, 1, 2, Gtk.Orientation.HORIZONTAL);
+        add_resize_box(Gdk.SurfaceEdge.NORTH, 1, 0, Gtk.Orientation.HORIZONTAL);
+        add_resize_box(Gdk.SurfaceEdge.EAST, 2, 1, Gtk.Orientation.VERTICAL);
+        add_resize_box(Gdk.SurfaceEdge.WEST, 0, 1, Gtk.Orientation.VERTICAL);
 
         this.settings.bind(
             'window-resizable',
@@ -241,20 +249,6 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
         });
         this.connect('destroy', () => this.settings.disconnect(edge_handler));
         this.update_window_pos();
-
-        this.connect('notify::screen', () => this.update_visual());
-        this.update_visual();
-
-        this.draw_handler = null;
-        this.connect('notify::app-paintable', this.setup_draw_handler.bind(this));
-        this.setup_draw_handler();
-
-        this.settings.bind(
-            'transparent-background',
-            this,
-            'app-paintable',
-            Gio.SettingsBindFlags.GET
-        );
 
         const HEIGHT_MOD = 0.05;
         const OPACITY_MOD = 0.05;
@@ -308,20 +302,6 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
         });
 
         this.settings.bind(
-            'window-skip-taskbar',
-            this,
-            'skip-taskbar-hint',
-            Gio.SettingsBindFlags.GET
-        );
-
-        this.settings.bind(
-            'window-skip-taskbar',
-            this,
-            'skip-pager-hint',
-            Gio.SettingsBindFlags.GET
-        );
-
-        this.settings.bind(
             'tab-show-shortcuts',
             this,
             'tab-show-shortcuts',
@@ -339,18 +319,11 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             }
         });
 
-        this._hide_on_close();
+        this.settings.connect('changed::window-skip-taskbar', this.update_skip_taskbar.bind(this));
+        this.connect('realize', this.update_skip_taskbar.bind(this));
+        this.update_skip_taskbar();
+
         this._setup_size_sync();
-    }
-
-    _hide_on_close() {
-        this.connect('delete-event', () => {
-            if (this.is_empty)
-                return false;
-
-            this.hide();
-            return true;
-        });
     }
 
     _setup_size_sync() {
@@ -376,11 +349,16 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
 
         this.connect('destroy', () => this.extension_dbus.disconnect(dbus_handler));
 
-        this.connect('unmap-event', () => {
+        this.connect('unmap', () => {
             this.sync_size_with_extension();
         });
 
         this.sync_size_with_extension();
+    }
+
+    vfunc_size_allocate(width, height, baseline) {
+        super.vfunc_size_allocate(width, height, baseline);
+        this.emit('size-allocate', width, height);
     }
 
     create_notebook() {
@@ -389,6 +367,7 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             scrollable: true,
             group_name: 'ddtermnotebook',
             menus: this.menus,
+            visible: false,
         });
 
         const update_notebook_visibility = () => {
@@ -502,18 +481,6 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
         return notebook;
     }
 
-    setup_draw_handler() {
-        if (this.app_paintable) {
-            if (!this.draw_handler)
-                this.draw_handler = this.connect('draw', this.draw.bind(this));
-        } else if (this.draw_handler) {
-            this.disconnect(this.draw_handler);
-            this.draw_handler = null;
-        }
-
-        this.queue_draw();
-    }
-
     adjust_double_setting(name, difference, min = 0.0, max = 1.0) {
         const current = this.settings.get_double(name);
         const new_setting = current + difference;
@@ -527,16 +494,16 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             this.present_with_time(Gdk.CURRENT_TIME);
     }
 
-    start_resizing(edge, source, event) {
-        const [button_ok, button] = event.get_button();
-        if (!button_ok || button !== Gdk.BUTTON_PRIMARY)
-            return;
-
-        const [coords_ok, x_root, y_root] = event.get_root_coords();
+    start_resizing(edge, gesture) {
+        const event = gesture.get_current_event();
+        const button = event.get_button?.() ?? 0;
+        const [coords_ok, x_root, y_root] = event.get_position();
         if (!coords_ok)
             return;
 
-        this.window.begin_resize_drag_for_device(
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED);
+
+        this.get_surface().begin_resize(
             edge,
             event.get_device(),
             button,
@@ -544,36 +511,8 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             y_root,
             event.get_time()
         );
-    }
 
-    update_visual() {
-        const visual = this.screen.get_rgba_visual();
-
-        if (visual)
-            this.set_visual(visual);
-    }
-
-    draw(_widget, cr) {
-        try {
-            if (!this.app_paintable)
-                return false;
-
-            if (!Gtk.cairo_should_draw_window(cr, this.window))
-                return false;
-
-            const context = this.get_style_context();
-            const allocation = this.get_child().get_allocation();
-            Gtk.render_background(
-                context, cr, allocation.x, allocation.y, allocation.width, allocation.height
-            );
-            Gtk.render_frame(
-                context, cr, allocation.x, allocation.y, allocation.width, allocation.height
-            );
-        } finally {
-            cr.$dispose();
-        }
-
-        return false;
+        gesture.reset();
     }
 
     sync_size_with_extension() {
@@ -597,17 +536,15 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             target_h = Math.floor(target_h / scale);
         }
 
-        this.resize(target_w, target_h);
-        this.window?.resize(target_w, target_h);
+        this.set_default_size(target_w, target_h);
     }
 
     update_tab_label_width() {
-        const [width] = this.get_size();
-        const tab_label_width = Math.floor(this.tab_label_width * width);
+        const tab_label_width = Math.floor(this.tab_label_width * this.get_width());
+        const { start_child, end_child } = this.paned;
 
-        this.paned.foreach(child => {
-            child.tab_label_width = tab_label_width;
-        });
+        start_child.tab_label_width = tab_label_width;
+        end_child.tab_label_width = tab_label_width;
     }
 
     get active_notebook() {
@@ -615,11 +552,15 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
     }
 
     get is_empty() {
-        return this.paned.get_children().every(nb => !nb.visible);
+        const { start_child, end_child } = this.paned;
+
+        return !start_child?.visible && !end_child?.visible;
     }
 
     get is_split() {
-        return this.paned.get_children().every(nb => nb.visible);
+        const { start_child, end_child } = this.paned;
+
+        return start_child?.visible && end_child?.visible;
     }
 
     get split_layout() {
@@ -636,17 +577,18 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
         if (!this.is_split)
             return;
 
-        const dst = this.paned.get_child1();
-        const src = this.paned.get_child2();
+        const dst = this.paned.start_child;
+        const src = this.paned.end_child;
         const current_page = this.active_notebook?.current_child;
 
         this.freeze_notify();
 
         try {
-            for (const child of src.get_children()) {
+            while (src.get_n_pages()) {
+                const child = src.get_nth_page(0);
                 const label = src.get_tab_label(child);
 
-                src.remove(child);
+                src.remove_page(0);
                 dst.insert_page(child, label, -1);
             }
 
@@ -664,9 +606,25 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
     }
 
     update_show_shortcuts() {
-        this.paned.foreach(child => {
-            child.tab_show_shortcuts = this.tab_show_shortcuts && child === this.active_notebook;
-        });
+        const { start_child, end_child } = this.paned;
+
+        start_child.tab_show_shortcuts =
+            this.tab_show_shortcuts && start_child === this.active_notebook;
+
+        end_child.tab_show_shortcuts =
+            this.tab_show_shortcuts && end_child === this.active_notebook;
+    }
+
+    update_skip_taskbar() {
+        const surface = this.get_surface();
+
+        if (surface?.constructor.$gtype.name !== 'GdkX11Toplevel')
+            return;
+
+        const skip = this.settings.get_boolean('window-skip-taskbar');
+
+        surface.set_skip_taskbar_hint(skip);
+        surface.set_skip_pager_hint(skip);
     }
 
     vfunc_grab_focus() {
@@ -675,12 +633,10 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             return;
         }
 
-        for (const notebook of this.paned.get_children()) {
-            if (notebook.visible) {
-                notebook.grab_focus();
-                return;
-            }
-        }
+        if (this.paned.start_child?.visible)
+            this.paned.start_child.grab_focus();
+        else if (this.paned.end_child?.visible)
+            this.paned.end_child.grab_focus();
     }
 
     serialize_state() {
@@ -704,8 +660,8 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             );
         }
 
-        properties.insert_value('notebook1', this.paned.get_child1().serialize_state());
-        properties.insert_value('notebook2', this.paned.get_child2().serialize_state());
+        properties.insert_value('notebook1', this.paned.start_child.serialize_state());
+        properties.insert_value('notebook2', this.paned.end_child.serialize_state());
 
         return properties.end();
     }
@@ -722,10 +678,10 @@ class DDTermAppWindow extends Gtk.ApplicationWindow {
             this.paned.orientation = orientation;
 
         if (notebook1_data)
-            this.paned.get_child1().deserialize_state(notebook1_data);
+            this.paned.start_child.deserialize_state(notebook1_data);
 
         if (notebook2_data)
-            this.paned.get_child2().deserialize_state(notebook2_data);
+            this.paned.end_child.deserialize_state(notebook2_data);
 
         if (position !== null)
             this.paned.position = (this.paned.max_position - this.paned.min_position) * position;

--- a/ddterm/app/dependencies.json
+++ b/ddterm/app/dependencies.json
@@ -1,32 +1,32 @@
 {
  "Gtk": {
-  "3.0": {
-   "arch": "gtk3",
-   "debian": "gir1.2-gtk-3.0",
-   "fedora": "gtk3",
-   "filename": "Gtk-3.0.typelib",
-   "suse": "typelib-1_0-Gtk-3_0",
-   "alpine": "gtk+3.0"
+  "4.0": {
+   "filename": "Gtk-4.0.typelib",
+   "arch": "gtk4",
+   "alpine": "gtk4.0",
+   "debian": "gir1.2-gtk-4.0",
+   "fedora": "gtk4",
+   "suse": "typelib-1_0-Gtk-4_0"
   }
  },
  "Gdk": {
-  "3.0": {
-   "arch": "gtk3",
-   "debian": "gir1.2-gtk-3.0",
-   "fedora": "gtk3",
-   "filename": "Gdk-3.0.typelib",
-   "suse": "typelib-1_0-Gtk-3_0",
-   "alpine": "gtk+3.0"
+  "4.0": {
+   "filename": "Gdk-4.0.typelib",
+   "arch": "gtk4",
+   "alpine": "gtk4.0",
+   "debian": "gir1.2-gtk-4.0",
+   "fedora": "gtk4",
+   "suse": "typelib-1_0-Gtk-4_0"
   }
  },
  "Vte": {
-  "2.91": {
-   "arch": "vte3",
-   "debian": "gir1.2-vte-2.91",
-   "fedora": "vte291",
-   "filename": "Vte-2.91.typelib",
-   "suse": "typelib-1_0-Vte-2.91",
-   "alpine": "vte3"
+  "3.91": {
+   "filename": "Vte-3.91.typelib",
+   "arch": "vte4",
+   "alpine": "vte3-gtk4",
+   "debian": "gir1.2-vte-3.91",
+   "fedora": "vte291-gtk4",
+   "suse": "typelib-1_0-Vte-3_91"
   }
  },
  "Pango": {
@@ -39,14 +39,14 @@
    "alpine": "pango"
   }
  },
- "Handy": {
+ "Adw": {
   "1": {
-   "filename": "Handy-1.typelib",
-   "arch": "libhandy",
-   "alpine": "libhandy1",
-   "suse": "typelib-1_0-Handy-1_0",
-   "fedora": "libhandy",
-   "debian": "gir1.2-handy-1"
+   "filename": "Adw-1.typelib",
+   "arch": "libadwaita",
+   "alpine": "libadwaita",
+   "debian": "gir1.2-adw-1",
+   "fedora": "libadwaita",
+   "suse": "typelib-1_0-Adw-1"
   }
  }
 }

--- a/ddterm/app/dev-appwindow.js
+++ b/ddterm/app/dev-appwindow.js
@@ -8,9 +8,6 @@ import { AppWindow as BaseAppWindow } from './appwindow.js';
 
 export const AppWindow = GObject.registerClass({
 }, class DDTermDevAppWindow extends BaseAppWindow {
-    _hide_on_close() {
-    }
-
     _setup_size_sync() {
     }
 });

--- a/ddterm/app/init.js
+++ b/ddterm/app/init.js
@@ -4,6 +4,7 @@
 
 import GObject from 'gi://GObject';
 
+import Gi from 'gi';
 import Gettext from 'gettext';
 
 import { metadata, dir } from './meta.js';
@@ -13,12 +14,18 @@ Gettext.bindtextdomain(metadata['gettext-domain'], dir.get_child('locale').get_p
 Gettext.textdomain(metadata['gettext-domain']);
 
 gi_require({
-    'Gtk': '3.0',
-    'Gdk': '3.0',
+    'Gtk': '4.0',
+    'Gdk': '4.0',
     'Pango': '1.0',
-    'Vte': '2.91',
-    'Handy': '1',
+    'Vte': '3.91',
+    'Adw': '1',
 });
+
+try {
+    Gi.require('GdkX11', '4.0');
+} catch (ex) {
+    logError(ex);
+}
 
 GObject.Object.prototype.disconnect = function (id) {
     if (GObject.signal_handler_is_connected(this, id))

--- a/ddterm/app/notebook.js
+++ b/ddterm/app/notebook.js
@@ -132,13 +132,13 @@ export const Notebook = GObject.registerClass({
         const button_box = new Gtk.Box({ visible: true });
 
         this.new_tab_button = new Gtk.Button({
-            image: Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU),
+            icon_name: 'list-add',
             tooltip_text: Gettext.gettext('New Tab (Last)'),
             action_name: 'notebook.new-tab',
-            relief: Gtk.ReliefStyle.NONE,
+            has_frame: false,
             visible: true,
         });
-        button_box.add(this.new_tab_button);
+        button_box.append(this.new_tab_button);
 
         this.bind_property(
             'show-new-tab-button',
@@ -154,11 +154,10 @@ export const Notebook = GObject.registerClass({
         this.tab_switch_button = new Gtk.MenuButton({
             menu_model: menu,
             focus_on_click: false,
-            relief: Gtk.ReliefStyle.NONE,
+            has_frame: false,
             visible: true,
-            use_popover: false,
         });
-        button_box.add(this.tab_switch_button);
+        button_box.append(this.tab_switch_button);
 
         this.bind_property(
             'show-tab-switch-popup',
@@ -170,10 +169,10 @@ export const Notebook = GObject.registerClass({
         this.set_action_widget(button_box, Gtk.PackType.END);
 
         this.new_tab_front_button = new Gtk.Button({
-            image: Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU),
+            icon_name: 'list-add',
             tooltip_text: Gettext.gettext('New Tab (First)'),
             action_name: 'notebook.new-tab-front',
-            relief: Gtk.ReliefStyle.NONE,
+            has_frame: false,
             visible: true,
         });
         this.set_action_widget(this.new_tab_front_button, Gtk.PackType.START);
@@ -255,9 +254,6 @@ export const Notebook = GObject.registerClass({
         this.connect('notify::tab-pos', this.update_tab_pos.bind(this));
         this.update_tab_pos();
 
-        this.connect('notify::tab-expand', this.update_tab_expand.bind(this));
-        this.update_tab_expand();
-
         this._current_child = null;
 
         this.connect('switch-page', (notebook, page) => {
@@ -293,7 +289,6 @@ export const Notebook = GObject.registerClass({
     on_page_added(child, page_num) {
         this.set_tab_reorderable(child, true);
         this.set_tab_detachable(child, true);
-        this.child_set_property(child, 'tab-expand', this.tab_expand);
 
         const handlers = [
             child.connect('new-tab-before-request', () => {
@@ -320,9 +315,13 @@ export const Notebook = GObject.registerClass({
             child.connect('move-to-other-pane-request', () => {
                 this.emit('move-to-other-pane', child);
             }),
+            child.connect('close', () => {
+                this.remove_page(this.page_num(child));
+            }),
         ];
 
         const label = this.get_tab_label(child);
+        const page = this.get_page(child);
 
         const bindings = [
             this.bind_property(
@@ -353,6 +352,12 @@ export const Notebook = GObject.registerClass({
                 'split-layout',
                 child,
                 'split-layout',
+                GObject.BindingFlags.SYNC_CREATE
+            ),
+            this.bind_property(
+                'tab-expand',
+                page,
+                'tab-expand',
                 GObject.BindingFlags.SYNC_CREATE
             ),
         ];
@@ -410,20 +415,14 @@ export const Notebook = GObject.registerClass({
     }
 
     update_tab_switch_actions() {
-        let i = 0;
+        const n_pages = this.get_n_pages();
 
-        this.foreach(child => {
-            const label = this.get_tab_label(child);
+        for (let i = 0; i < n_pages; i++) {
+            const label = this.get_tab_label(this.get_nth_page(i));
 
-            label.action_target = GLib.Variant.new_int32(i++);
+            label.action_target = GLib.Variant.new_int32(i);
             label.action_name = 'notebook.switch-to-tab';
-        });
-    }
-
-    update_tab_expand() {
-        this.foreach(page => {
-            this.child_set_property(page, 'tab-expand', this.tab_expand);
-        });
+        }
     }
 
     update_tabs_visible() {
@@ -477,9 +476,12 @@ export const Notebook = GObject.registerClass({
         const properties = GLib.VariantDict.new(null);
         const variant_dict_type = new GLib.VariantType('a{sv}');
         const pages = [];
+        const n_pages = this.get_n_pages();
 
-        for (const page of this.get_children()) {
+        for (let i = 0; i < n_pages; i++) {
             try {
+                const page = this.get_nth_page(i);
+
                 pages.push(page.serialize_state());
             } catch (ex) {
                 logError(ex, "Can't serialize terminal state");
@@ -568,11 +570,16 @@ const NotebookMenu = GObject.registerClass({
 
     _update() {
         const prev_length = this.get_n_items();
+        const update = [];
+        const n_pages = this.notebook.get_n_pages();
 
-        this._label = this.notebook.get_children().map(page => page.title);
-        this._target.length = this._label.length;
+        for (let i = 0; i < n_pages; i++)
+            update.push(this.notebook.get_nth_page(i).title);
 
-        this.items_changed(0, prev_length, this._label.length);
+        this._label = update;
+        this._target.length = update.length;
+
+        this.items_changed(0, prev_length, update.length);
     }
 
     _schedule_update() {

--- a/ddterm/app/terminalpage.js
+++ b/ddterm/app/terminalpage.js
@@ -77,6 +77,7 @@ export const TerminalPage = GObject.registerClass({
         ),
     },
     Signals: {
+        'close': {},
         'new-tab-before-request': {},
         'new-tab-after-request': {},
         'move-prev-request': {},
@@ -90,36 +91,29 @@ export const TerminalPage = GObject.registerClass({
     _init(params) {
         super._init(params);
 
-        const terminal_with_scrollbar = new Gtk.Box({
-            visible: true,
-            orientation: Gtk.Orientation.HORIZONTAL,
-        });
+        this.orientation = Gtk.Orientation.VERTICAL;
 
         this.terminal = new Terminal({
             visible: true,
             context_menu_model: this.terminal_menu,
+            vexpand: true,
         });
-
-        terminal_with_scrollbar.pack_start(this.terminal, true, true, 0);
 
         this.terminal_settings.bind_terminal(this.terminal);
 
-        this.scrollbar = new Gtk.Scrollbar({
-            orientation: Gtk.Orientation.VERTICAL,
-            adjustment: this.terminal.vadjustment,
-            visible: true,
+        this.scrolled_window = new Gtk.ScrolledWindow({
+            child: this.terminal,
+            hscrollbar_policy: Gtk.PolicyType.NEVER,
+            vscrollbar_policy: Gtk.PolicyType.NEVER,
         });
 
-        terminal_with_scrollbar.pack_end(this.scrollbar, false, false, 0);
-
-        this.orientation = Gtk.Orientation.VERTICAL;
+        this.append(this.scrolled_window);
 
         this.search_bar = new SearchBar({
             visible: true,
         });
 
-        this.pack_end(this.search_bar, false, false, 0);
-        this.pack_end(terminal_with_scrollbar, true, true, 0);
+        this.append(this.search_bar);
 
         this.search_bar.connect('find-next', this.find_next.bind(this));
         this.search_bar.connect('find-prev', this.find_prev.bind(this));
@@ -136,16 +130,9 @@ export const TerminalPage = GObject.registerClass({
         });
 
         this.tab_label = new TabLabel({
-            visible_window: false,
             context_menu_model: this.tab_menu,
         });
 
-        const tab_label_destroy_handler =
-            this.connect('destroy', () => this.tab_label.destroy());
-
-        this.tab_label.connect('destroy', () => {
-            this.disconnect(tab_label_destroy_handler);
-        });
         this.tab_label.connect('close', () => this.close());
         this.tab_label.connect('reset-label', () => {
             this.use_custom_title = false;
@@ -158,17 +145,21 @@ export const TerminalPage = GObject.registerClass({
             GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.BIDIRECTIONAL
         );
 
-        this.terminal_settings.bind_property(
+        this.terminal_settings.bind_property_full(
             'show-scrollbar',
-            this.scrollbar,
-            'visible',
-            GObject.BindingFlags.SYNC_CREATE
+            this.scrolled_window,
+            'vscrollbar-policy',
+            GObject.BindingFlags.SYNC_CREATE,
+            (binding, value) => [true, value ? Gtk.PolicyType.ALWAYS : Gtk.PolicyType.NEVER],
+            null
         );
 
-        this.terminal.connect(
-            'button-press-event',
-            this.terminal_button_press_early.bind(this)
-        );
+        const early_click = Gtk.GestureClick.new();
+        early_click.propagation_phase = Gtk.PropagationPhase.CAPTURE;
+        early_click.button = 0;
+        early_click.exclusive = true;
+        early_click.connect('pressed', this.terminal_button_press_early.bind(this));
+        this.terminal.add_controller(early_click);
 
         const page_actions = new Gio.SimpleActionGroup();
 
@@ -412,7 +403,7 @@ export const TerminalPage = GObject.registerClass({
             if (this.keep_open_after_exit)
                 this.add_exit_status_banner(status);
             else
-                this.destroy();
+                this.emit('close');
         });
     }
 
@@ -432,7 +423,7 @@ export const TerminalPage = GObject.registerClass({
             revealed: true,
         });
 
-        banner.get_content_area().pack_start(label, false, false, 0);
+        banner.add_child(label);
         banner.add_button(Gettext.gettext('Restart'), 0);
         banner.add_button(Gettext.gettext('Close Terminal'), 1);
 
@@ -443,12 +434,12 @@ export const TerminalPage = GObject.registerClass({
                 banner.destroy();
                 break;
             case 1:
-                this.destroy();
+                this.emit('close');
                 break;
             }
         });
 
-        this.pack_start(banner, false, false, 0);
+        this.prepend(banner, false, false, 0);
     }
 
     add_exit_status_banner(status) {
@@ -494,7 +485,7 @@ export const TerminalPage = GObject.registerClass({
     }
 
     open_hyperlink() {
-        Gtk.show_uri_on_window(
+        Gtk.show_uri(
             this.get_ancestor(Gtk.Window),
             this.terminal.last_clicked_hyperlink,
             Gdk.CURRENT_TIME
@@ -511,13 +502,9 @@ export const TerminalPage = GObject.registerClass({
         clipboard.set_text(this.terminal.last_clicked_filename, -1);
     }
 
-    terminal_button_press_early(_terminal, event) {
-        const state = event.get_state()[1];
-
-        if (state & Gdk.ModifierType.CONTROL_MASK) {
-            const button = event.get_button()[1];
-
-            if ([Gdk.BUTTON_PRIMARY, Gdk.BUTTON_MIDDLE].includes(button)) {
+    terminal_button_press_early(gesture) {
+        if (gesture.get_current_event_state() & Gdk.ModifierType.CONTROL_MASK) {
+            if ([Gdk.BUTTON_PRIMARY, Gdk.BUTTON_MIDDLE].includes(gesture.get_current_button())) {
                 this.open_hyperlink();
                 return true;
             }
@@ -537,12 +524,12 @@ export const TerminalPage = GObject.registerClass({
     }
 
     find() {
-        this.terminal.get_text_selected_async().then(text => {
-            if (text)
-                this.search_bar.pattern.text = text;
+        const text = this.terminal.get_text_selected?.(Vte.Format.TEXT);
 
-            this.search_bar.reveal_child = true;
-        });
+        if (text)
+            this.search_bar.pattern.text = text;
+
+        this.search_bar.reveal_child = true;
     }
 
     show_in_file_manager() {
@@ -569,12 +556,12 @@ export const TerminalPage = GObject.registerClass({
 
     close() {
         if (!this.terminal.has_foreground_process()) {
-            this.destroy();
+            this.emit('close');
             return;
         }
 
         const message = new Gtk.MessageDialog({
-            transient_for: this.get_toplevel(),
+            transient_for: this.root,
             modal: true,
             buttons: Gtk.ButtonsType.CANCEL,
             message_type: Gtk.MessageType.WARNING,
@@ -594,7 +581,7 @@ export const TerminalPage = GObject.registerClass({
 
         message.connect('response', (_, response_id) => {
             if (response_id === Gtk.ResponseType.ACCEPT)
-                this.destroy();
+                this.emit('close');
 
             message.destroy();
         });

--- a/ddterm/app/urldetect.js
+++ b/ddterm/app/urldetect.js
@@ -122,8 +122,8 @@ export const UrlDetect = GObject.registerClass({
         });
     }
 
-    check_event(event) {
-        const [url, tag] = this.terminal.match_check_event(event);
+    check_match_at(x, y) {
+        const [url, tag] = this.terminal.check_match_at(x, y);
 
         if (url && tag !== null && this._url_prefix.has(tag)) {
             const prefix = this._url_prefix.get(tag);

--- a/meson.build
+++ b/meson.build
@@ -38,8 +38,8 @@ if get_option('esm')
   pack_name = f'@uuid@.shell-extension.zip'
 else
   gjs_req = '>=1.72.0'
-  gnome_shell_req = ['>=42.0', '<45.0']
-  shell_versions = ['42', '43', '44']
+  gnome_shell_req = ['>=43.0', '<45.0']
+  shell_versions = ['43', '44']
 
   extension_main_src_file = files('extension.legacy.js')
   prefs_main_src_file = files('prefs.legacy.js')

--- a/tests/apphook.js
+++ b/tests/apphook.js
@@ -177,29 +177,31 @@ class DebugInterface {
                 if (win === this.window)
                     this.connect_window(null);
             }),
-            connect(win, 'event', (_, event) => {
-                this.emit_event(event);
+            connect(win, 'realize', w => {
+                const surface = w.get_surface();
 
-                return false;
-            }),
-            connect(win, 'configure-event', () => {
-                this.emit_configure_event(win.get_size());
+                this.disconnect_callbacks.push(
+                    connect(surface, 'layout', (_, width, height) => {
+                        this.emit_window_layout(width, height);
+                    }),
+                    connect(surface, 'notify::state', s => {
+                        this.emit_toplevel_state(s.state);
+                    }),
+                    connect(surface, 'event', (_, event) => {
+                        this.emit_event(event);
 
-                return false;
+                        return false;
+                    })
+                );
             }),
-            connect(win, 'window-state-event', () => {
-                this.emit_window_state_event(win.window.get_state());
-
-                return false;
-            }),
-            connect(win, 'size-allocate', (_, rect) => {
-                this.emit_size_allocate(rect);
+            connect(win, 'size-allocate', (_, width, height) => {
+                this.emit_size_allocate(width, height);
             }),
         ];
 
         const notify_num_tabs = this.notify_num_tabs.bind(this);
 
-        for (const notebook of [win.paned.get_child1(), win.paned.get_child2()]) {
+        for (const notebook of [win.paned.start_child, win.paned.end_child]) {
             this.disconnect_callbacks.push(connect(notebook, 'page-added', notify_num_tabs));
             this.disconnect_callbacks.push(connect(notebook, 'page-removed', notify_num_tabs));
         }
@@ -217,25 +219,23 @@ class DebugInterface {
         );
     }
 
-    emit_configure_event([width, height]) {
+    emit_window_layout(width, height) {
         this.dbus.emit_signal(
-            'ConfigureEvent',
+            'WindowLayout',
             GLib.Variant.new_tuple([GLib.Variant.new_int32(width), GLib.Variant.new_int32(height)])
         );
     }
 
-    emit_window_state_event(state) {
-        state = GObject.flags_to_string(Gdk.WindowState, state).split(' | ');
+    emit_toplevel_state(state) {
+        state = GObject.flags_to_string(Gdk.ToplevelState, state).split(' | ');
 
         this.dbus.emit_signal(
-            'WindowStateEvent',
+            'ToplevelState',
             GLib.Variant.new_tuple([GLib.Variant.new_strv(state)])
         );
     }
 
-    emit_size_allocate(rect) {
-        const { width, height } = rect;
-
+    emit_size_allocate(width, height) {
         this.dbus.emit_signal(
             'SizeAllocate',
             GLib.Variant.new_tuple([GLib.Variant.new_int32(width), GLib.Variant.new_int32(height)])
@@ -260,7 +260,7 @@ class DebugInterface {
 
     WaitFrameAsync(params, invocation) {
         try {
-            const frame_clock = this.window.window.get_frame_clock();
+            const frame_clock = this.window.get_frame_clock();
 
             const handler = frame_clock.connect_after('after-paint', () => {
                 frame_clock.disconnect(handler);
@@ -321,10 +321,7 @@ class DebugInterface {
                 deepest_scope = focus_widget;
         }
 
-        const [prefix, name] = action_name.split('.');
-        const actions = deepest_scope.get_action_group(prefix);
-
-        actions.activate_action(name, target_value);
+        deepest_scope.activate_action(action_name, target_value);
     }
 
     get Connected() {
@@ -337,7 +334,7 @@ class DebugInterface {
 
         const { paned } = this.window;
 
-        return paned.get_child1().get_n_pages() + paned.get_child2().get_n_pages();
+        return paned.start_child.get_n_pages() + paned.end_child.get_n_pages();
     }
 
     notify_num_tabs() {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -410,9 +410,11 @@ def global_environment(container, request):
     if not request.config.option.hw_accel:
         env['LIBGL_ALWAYS_SOFTWARE'] = 'true'
         env['GBM_ALWAYS_SOFTWARE'] = 'true'
+        env['GSK_RENDERER'] = 'cairo'
 
     env['NO_AT_BRIDGE'] = '1'
     env['GTK_A11Y'] = 'none'
+    env['ADW_DISABLE_PORTAL'] = '1'
 
     return env
 

--- a/tests/dbus-interfaces/com.github.amezin.ddterm.Debug.xml
+++ b/tests/dbus-interfaces/com.github.amezin.ddterm.Debug.xml
@@ -25,11 +25,11 @@
         <signal name="WindowEvent">
             <arg type="s"/>
         </signal>
-        <signal name="ConfigureEvent">
+        <signal name="WindowLayout">
             <arg type="i" name="width"/>
             <arg type="i" name="height"/>
         </signal>
-        <signal name="WindowStateEvent">
+        <signal name="ToplevelState">
             <arg type="as"/>
         </signal>
         <signal name="SizeAllocate">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,7 +19,7 @@ SRC_DIR = THIS_DIR.parent
 
 LOGGER = logging.getLogger(__name__)
 
-GC_CYCLES = 2
+GC_CYCLES = 20
 
 
 def diff_heap(dump_old, dump_new, hide_node=[], hide_edge=[], gray_roots=True, weak_maps=True):

--- a/tests/test_wm.py
+++ b/tests/test_wm.py
@@ -178,7 +178,7 @@ def wait_idle(
                 )
             )
 
-        for signal in ('ConfigureEvent', 'WindowStateEvent', 'SizeAllocate'):
+        for signal in ('WindowLayout', 'ToplevelState', 'SizeAllocate'):
             stack.enter_context(
                 glibutil.signal_handler(
                     app_debug_dbus_interface,


### PR DESCRIPTION
https://github.com/ddterm/gnome-shell-extension-ddterm/issues/652

- Memory leaks
- 50% of WM tests fail
- Closing a tab/page doesn't kill the child process
- No transparent background

`WeakRef`s work correctly only starting from GJS 1.80/GNOME 46. Fix was backported to GNOME 45 branch, but most distros didn't update to GJS 1.78.5 patch. `GObject.connect_object` also available starting from GJS 1.80/GNOME 46 only. So I'm trying to break reference cycles in widget's `unrealize`.

I hate GJS.