### PR TITLE
Don't restart terminated processes during session restore

### DIFF
--- a/ddterm/app/notebook.js
+++ b/ddterm/app/notebook.js
@@ -508,7 +508,9 @@ export const Notebook = GObject.registerClass({
                 });
 
                 this.append_page(page, page.tab_label);
-                page.spawn();
+
+                if (!page.banner_visible)
+                    page.spawn();
             } catch (ex) {
                 logError(ex, "Can't restore terminal");
             }

--- a/ddterm/app/terminal.js
+++ b/ddterm/app/terminal.js
@@ -327,6 +327,11 @@ const TerminalBase = GObject.registerClass({
 
         super._init(params);
 
+        this.connect('child-exited', () => {
+            this._child_pid = 0;
+            this.notify('child-pid');
+        });
+
         this._url_detect = new UrlDetect({
             terminal: this,
             enabled_patterns: this.url_detect_patterns,

--- a/ddterm/app/terminalpage.js
+++ b/ddterm/app/terminalpage.js
@@ -694,11 +694,6 @@ export const TerminalPage = GObject.registerClass({
             GLib.Variant.new_boolean(this.keep_open_after_exit)
         );
 
-        properties.insert_value(
-            'banner-visible',
-            GLib.Variant.boolean(this.banner_visible)
-        );
-
         if (this.banner_visible) {
             properties.insert_value(
                 'banner-type',

--- a/ddterm/app/terminalpage.js
+++ b/ddterm/app/terminalpage.js
@@ -632,11 +632,15 @@ export const TerminalPage = GObject.registerClass({
         const command = cwd ? this.command.override_working_directory(cwd) : this.command;
 
         properties.insert_value('command', command.to_gvariant());
-        properties.insert_value('title', GLib.Variant.new_string(this.title));
+
+        if (this.title)
+            properties.insert_value('title', GLib.Variant.new_string(this.title));
+
         properties.insert_value(
             'use-custom-title',
             GLib.Variant.new_boolean(this.use_custom_title)
         );
+
         properties.insert_value(
             'keep-open-after-exit',
             GLib.Variant.new_boolean(this.keep_open_after_exit)
@@ -660,9 +664,9 @@ export const TerminalPage = GObject.registerClass({
         const command_data = dict.lookup_value('command', variant_dict_type);
         const page = new TerminalPage({
             command: command_data ? TerminalCommand.from_gvariant(command_data) : null,
-            title: dict.lookup('title', 's'),
-            use_custom_title: dict.lookup('use-custom-title', 'b'),
-            keep_open_after_exit: dict.lookup('keep-open-after-exit', 'b'),
+            title: dict.lookup('title', 's') ?? '',
+            use_custom_title: dict.lookup('use-custom-title', 'b') ?? false,
+            keep_open_after_exit: dict.lookup('keep-open-after-exit', 'b') ?? false,
             ...properties,
         });
 

--- a/ddterm/app/terminalpage.js
+++ b/ddterm/app/terminalpage.js
@@ -694,6 +694,25 @@ export const TerminalPage = GObject.registerClass({
             GLib.Variant.new_boolean(this.keep_open_after_exit)
         );
 
+        properties.insert_value(
+            'banner-visible',
+            GLib.Variant.boolean(this.banner_visible)
+        );
+
+        if (this.banner_visible) {
+            properties.insert_value(
+                'banner-type',
+                GLib.Variant.new_int32(this.banner_type)
+            );
+
+            if (this.banner_label) {
+                properties.insert_value(
+                    'banner',
+                    GLib.Variant.new_string(this.banner_label)
+                );
+            }
+        }
+
         try {
             const text = this.terminal.get_text()?.trim();
 
@@ -715,6 +734,9 @@ export const TerminalPage = GObject.registerClass({
             title: dict.lookup('title', 's') ?? '',
             use_custom_title: dict.lookup('use-custom-title', 'b') ?? false,
             keep_open_after_exit: dict.lookup('keep-open-after-exit', 'b') ?? false,
+            banner_label: dict.lookup('banner', 's') ?? '',
+            banner_type: dict.lookup('banner-type', 'i') ?? Gtk.MessageType.INFO,
+            banner_visible: dict.contains('banner-type'),
             ...properties,
         });
 

--- a/ddterm/app/terminalpage.js
+++ b/ddterm/app/terminalpage.js
@@ -303,7 +303,8 @@ export const TerminalPage = GObject.registerClass({
         this.connect('notify::use-custom-title', () => {
             this.update_title_binding();
         });
-        this.update_title_binding();
+        // Don't update the title from the terminal until the process is started
+        this.update_title_binding(false);
 
         const use_custom_title_action = new Gio.SimpleAction({
             'name': 'use-custom-title',
@@ -651,7 +652,7 @@ export const TerminalPage = GObject.registerClass({
         message.show();
     }
 
-    update_title_binding() {
+    update_title_binding(sync = true) {
         const enable = !this.use_custom_title;
 
         if (enable === Boolean(this._title_binding))
@@ -662,7 +663,7 @@ export const TerminalPage = GObject.registerClass({
                 'window-title',
                 this,
                 'title',
-                GObject.BindingFlags.SYNC_CREATE
+                sync ? GObject.BindingFlags.SYNC_CREATE : GObject.BindingFlags.DEFAULT
             );
         } else {
             this._title_binding?.unbind();

--- a/tests/apphook.js
+++ b/tests/apphook.js
@@ -284,6 +284,20 @@ class DebugInterface {
         }
     }
 
+    WaitTimeAsync(params, invocation) {
+        const [interval_ms] = params;
+
+        try {
+            GLib.timeout_add(GLib.PRIORITY_LOW, interval_ms, () => {
+                invocation.return_value(null);
+
+                return GLib.SOURCE_REMOVE;
+            });
+        } catch (ex) {
+            return_error(invocation, ex);
+        }
+    }
+
     GC() {
         System.gc();
     }

--- a/tests/dbus-interfaces/com.github.amezin.ddterm.Debug.xml
+++ b/tests/dbus-interfaces/com.github.amezin.ddterm.Debug.xml
@@ -15,6 +15,9 @@
         </method>
         <method name="WaitFrame"/>
         <method name="WaitIdle"/>
+        <method name="WaitTime">
+            <arg type="i" name="interval_ms" direction="in"/>
+        </method>
         <method name="GC"/>
         <method name="DumpHeap">
             <arg type="s" name="path" direction="in"/>


### PR DESCRIPTION
Don't restart processes that terminated before the session was saved.

Fixes https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1277