### PR TITLE
ci: don't pin Arch Linux container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     container:
-      image: ghcr.io/archlinux/archlinux:base-devel-20250615.0.366009@sha256:ed70edfd2bda2f511c0c0a4211f1e26f1565b2aba0421297949cdbdd7ca3e1f8
+      image: ghcr.io/archlinux/archlinux:base-devel
       options: --privileged --tmpfs /run
 
     steps:
@@ -363,7 +363,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     container:
-      image: ghcr.io/archlinux/archlinux:base-devel-20250615.0.366009@sha256:ed70edfd2bda2f511c0c0a4211f1e26f1565b2aba0421297949cdbdd7ca3e1f8
+      image: ghcr.io/archlinux/archlinux:base-devel
       options: --privileged --tmpfs /run
 
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -35,20 +35,14 @@
     },
     {
       "matchPackageNames": [
-        "ghcr.io/archlinux/archlinux"
-      ],
-      "automerge": true,
-      "versionCompatibility": "^(?<compatibility>\\D+)?(?<version>[\\d\\.]+)$"
-    },
-    {
-      "matchPackageNames": [
         "ghcr.io/ddterm/gnome-shell-image/**"
       ],
       "groupName": "GNOME Shell Container Images"
     },
     {
       "matchPackageNames": [
-        "ghcr.io/ddterm/**"
+        "ghcr.io/ddterm/**",
+        "ghcr.io/archlinux/archlinux"
       ],
       "pinDigests": false,
       "automerge": true


### PR DESCRIPTION
It's pointless. A lot of packages will be installed or updated from the repositories - so the image doesn't really matter