### PR TITLE
app/launcher: use `runAsync()`, allow `System.exit()` from app code

### DIFF
--- a/ddterm/app/dependencies.js
+++ b/ddterm/app/dependencies.js
@@ -6,6 +6,7 @@ import GLib from 'gi://GLib';
 
 import Gettext from 'gettext';
 import Gi from 'gi';
+import System from 'system';
 
 import { create_extension_dbus_proxy_oneshot } from './extensiondbus.js';
 import { get_resource_file, get_resource_text } from './resources.js';
@@ -97,20 +98,12 @@ export function gi_require_optional(imports_versions) {
     return loaded;
 }
 
-class MissingDependenciesError extends Error {
-    constructor(message) {
-        super(message);
-
-        this.name = 'MissingDependenciesError';
-    }
-}
-
 export function gi_require(imports_versions) {
     const loaded = gi_require_optional(imports_versions);
 
     if (Object.getOwnPropertyNames(loaded).length !==
         Object.getOwnPropertyNames(imports_versions).length)
-        throw new MissingDependenciesError();
+        System.exit(1);
 
     return loaded;
 }


### PR DESCRIPTION
Will probably fix some weird freezes (where a critical error should've caused quick exit but the app hung instead).

Also reduces the number of lines.