### PR TITLE
extension: pass `Service` instead of `Subprocess` to `WindowMatch`

### DIFF
--- a/ddterm/shell/extension.js
+++ b/ddterm/shell/extension.js
@@ -28,28 +28,6 @@ const APP_ID = 'com.github.amezin.ddterm';
 const APP_DBUS_PATH = '/com/github/amezin/ddterm';
 const WINDOW_PATH_PREFIX = `${APP_DBUS_PATH}/window/`;
 
-function create_window_matcher(service, rollback) {
-    const window_matcher = new WindowMatch({
-        subprocess: service.subprocess,
-        display: global.display,
-        gtk_application_id: APP_ID,
-        gtk_window_object_path_prefix: WINDOW_PATH_PREFIX,
-    });
-
-    rollback.push(() => {
-        window_matcher.disable();
-    });
-
-    service.bind_property(
-        'subprocess',
-        window_matcher,
-        'subprocess',
-        GObject.BindingFlags.DEFAULT
-    );
-
-    return window_matcher;
-}
-
 function create_dbus_interface(
     window_geometry,
     window_matcher,
@@ -345,7 +323,16 @@ class EnabledExtension {
             'hide-animation-duration'
         );
 
-        this.window_matcher = create_window_matcher(this.service, rollback);
+        this.window_matcher = new WindowMatch({
+            service: this.service,
+            display: global.display,
+            gtk_application_id: APP_ID,
+            gtk_window_object_path_prefix: WINDOW_PATH_PREFIX,
+        });
+
+        rollback.push(() => {
+            this.window_matcher.disable();
+        });
 
         this.app_control = new AppControl({
             service: this.service,

--- a/ddterm/shell/service.js
+++ b/ddterm/shell/service.js
@@ -107,10 +107,11 @@ export const Service = GObject.registerClass({
         super(rest);
 
         this.#subprocess = subprocess;
-        this.#subprocess_running = subprocess?.is_running ?? false;
 
-        if (subprocess)
+        if (subprocess) {
+            this.#subprocess_running = true;
             this.#subprocess_wait = this.#wait_subprocess();
+        }
 
         this.#bus_watch = Gio.bus_watch_name_on_connection(
             this.bus,
@@ -123,6 +124,10 @@ export const Service = GObject.registerClass({
 
     get subprocess() {
         return this.#subprocess;
+    }
+
+    owns_window(win) {
+        return this.#subprocess_running && this.#subprocess.owns_window(win);
     }
 
     get bus_name_owner() {

--- a/ddterm/shell/subprocess.js
+++ b/ddterm/shell/subprocess.js
@@ -249,14 +249,15 @@ export const Subprocess = GObject.registerClass({
         return this._subprocess;
     }
 
-    is_running() {
-        return Boolean(this._subprocess.get_identifier());
-    }
-
     owns_window(win) {
+        const win_pid = win.get_pid();
+
+        if (!win_pid)
+            return false;
+
         const identifier = this._subprocess.get_identifier();
 
-        return identifier && win.get_pid().toString() === identifier;
+        return identifier && identifier === win_pid.toString();
     }
 
     wait(cancellable = null) {

--- a/ddterm/shell/windowmatch.js
+++ b/ddterm/shell/windowmatch.js
@@ -7,7 +7,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Meta from 'gi://Meta';
 
-import { Subprocess } from './subprocess.js';
+import { Service } from './service.js';
 
 export const WindowMatchGeneric = GObject.registerClass({
     Properties: {
@@ -84,12 +84,12 @@ export const WindowMatchGeneric = GObject.registerClass({
 
 export const WindowMatch = GObject.registerClass({
     Properties: {
-        'subprocess': GObject.ParamSpec.object(
-            'subprocess',
+        'service': GObject.ParamSpec.object(
+            'service',
             '',
             '',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.EXPLICIT_NOTIFY,
-            Subprocess
+            Service
         ),
         'current-window': GObject.ParamSpec.object(
             'current-window',
@@ -138,7 +138,7 @@ export const WindowMatch = GObject.registerClass({
         if (win === this._window)
             return GLib.SOURCE_REMOVE;
 
-        if (!this.subprocess?.owns_window(win)) {
+        if (!this.service.owns_window(win)) {
             /*
                 With X11 window:
                 - Shell can be restarted without logging out
@@ -147,7 +147,7 @@ export const WindowMatch = GObject.registerClass({
                 So if we did not launch the app, allow this check to be skipped
                 on X11.
             */
-            if (this.subprocess?.is_running())
+            if (this.service.is_running)
                 return GLib.SOURCE_REMOVE;
 
             if (win.get_client_type() === Meta.WindowClientType.WAYLAND)


### PR DESCRIPTION
When calling `.owns_window()` on a `WaylandClient` with terminated subprocess:

    gnome-shell[2299]: meta_wayland_client_owns_window: assertion 'client->subprocess.process_running' failed

Service already tracks subprocess running state, so proxy `.owns_window()` through it.