### PR TITLE
Update pytest-html

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,7 +5,7 @@
 --only-binary :all:
 
 pytest==8.4.2
-pytest-html==3.2.0
+pytest-html==4.1.1
 ansi2html==1.9.2
 pyyaml==6.0.2
 pytest-xdist[psutil,setproctitle]==3.8.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,14 +12,16 @@ execnet==2.1.1
     # via pytest-xdist
 iniconfig==2.1.0
     # via pytest
+jinja2==3.1.6
+    # via pytest-html
+markupsafe==3.0.2
+    # via jinja2
 packaging==25.0
     # via pytest
 pluggy==1.6.0
     # via pytest
 psutil==7.0.0
     # via pytest-xdist
-py==1.11.0
-    # via pytest-html
 pygments==2.19.2
     # via pytest
 pytest==8.4.2
@@ -28,7 +30,7 @@ pytest==8.4.2
     #   pytest-html
     #   pytest-metadata
     #   pytest-xdist
-pytest-html==3.2.0
+pytest-html==4.1.1
     # via -r test.in
 pytest-metadata==3.1.1
     # via pytest-html

--- a/tox.ini
+++ b/tox.ini
@@ -39,11 +39,6 @@ commands =
 [testenv:pytest]
 description = Run tests using pytest (advanced)
 deps = -r tests/requirements.txt
-
-# https://github.com/pytest-dev/pytest/issues/10451
-commands_pre = rm -f '{envsitepackagesdir}/py.py'
-allowlist_externals = rm
-
 commands = {envpython} -m pytest --html=tests/report.html --dist=worksteal {posargs}
 
 [testenv:meson{,-test}]
@@ -62,7 +57,6 @@ deps =
 changedir = {toxinidir}/build
 
 commands_pre =
-    test: {[testenv:pytest]commands_pre}
     test: {envpython} -m mesonbuild.mesonmain setup -Dtests=enabled {toxinidir}
     !test: {envpython} -m mesonbuild.mesonmain setup {toxinidir}
 


### PR DESCRIPTION
v4.x performance is still abysmal, but v3.x output is sometimes unreadable now.