### PR TITLE
List contributors in `AUTHORS` file instead of `package.json`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: NONE
+# SPDX-License-Identifier: CC0-1.0
+
+Aleksandr Mezin <mezin.alexander@gmail.com> (https://github.com/amezin)
+
+# Contributors, in "Your Name <e@mail> (url)" format (e-mail and URL are optional):
+Pedro Sader Azevedo (https://github.com/pesader)
+Lingfeng Zhang (https://github.com/ccat3z)
+Jackson Goode (https://github.com/jacksongoode)
+Mohammad Javad Naderi (https://github.com/mjnaderi)
+Juan M. Cruz-Martinez (https://github.com/scarlehoff)
+Samuel Bachmann (https://github.com/samuelba)
+Vicente Maroto Garzón (https://github.com/C-512L)
+Timothy J. Aveni (https://github.com/SyntaxBlitz)
+Egor Sukov (https://github.com/Zerocool56)
+k-c13 (https://github.com/mokilcde)
+Maximilien Richer (https://github.com/halfa)
+Jing Yen (https://github.com/JingYenLoh)
+Ivan Peshekhonov (https://github.com/vancomm)
+Anton Leontiev (https://github.com/bunder)
+
+# Artwork by:
+luk (https://github.com/thenameisluk)

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -10,11 +10,6 @@ SPDX-PackageHomePage = "https://github.com/ddterm/gnome-shell-extension-ddterm/"
 SPDX-PackageLicenseDeclared = "GPL-3.0-or-later"
 
 [[annotations]]
-path = "package.json"
-SPDX-FileCopyrightText = "2021 Aleksandr Mezin <mezin.alexander@gmail.com>"
-SPDX-License-Identifier = "CC0-1.0"
-
-[[annotations]]
 path = "locale/**/LC_MESSAGES/*.mo"
 SPDX-FileCopyrightText = "ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>"
 SPDX-License-Identifier = "GPL-3.0-or-later"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,10 +37,9 @@ If you want to report a bug, please proceed to the [bug reporting form].
 
 > [!TIP]
 > If you want to be mentioned in application's "About" dialog,
-> you could add yourself to [`"contributors"` array] in [`package.json`] file.
+> you could also add yourself to the [`AUTHORS`] file.
 
-[`"contributors"` array]: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#people-fields-author-contributors
-[`package.json`]: /package.json
+[`AUTHORS`]: /AUTHORS
 
 If you want to implement a feature, or fix a bug, you may find these documents
 useful:

--- a/meson.build
+++ b/meson.build
@@ -167,7 +167,7 @@ pack = [
   fs.copyfile('revision.txt.in.license', 'revision.txt.license'),
 ]
 
-foreach f : ['extension.js', 'prefs.js', 'package.json']
+foreach f : ['extension.js', 'prefs.js', 'AUTHORS']
   pack += fs.copyfile(f, install: true, install_dir: extension_dir)
 endforeach
 

--- a/package.json
+++ b/package.json
@@ -10,68 +10,6 @@
         "email": "mezin.alexander@gmail.com",
         "url": "https://github.com/amezin"
     },
-    "contributors": [
-        {
-            "name": "Pedro Sader Azevedo",
-            "url": "https://github.com/pesader"
-        },
-        {
-            "name": "Mohammad Javad Naderi",
-            "url": "https://github.com/mjnaderi"
-        },
-        {
-            "name": "Maximilien Richer",
-            "url": "https://github.com/halfa"
-        },
-        {
-            "name": "Timothy J. Aveni",
-            "url": "https://github.com/SyntaxBlitz"
-        },
-        {
-            "name": "Ivan Peshekhonov",
-            "url": "https://github.com/vancomm"
-        },
-        {
-            "name": "Egor Sukov",
-            "url": "https://github.com/Zerocool56"
-        },
-        {
-            "name": "Anton Leontiev",
-            "url": "https://github.com/bunder"
-        },
-        {
-            "name": "Jing Yen Loh",
-            "url": "https://github.com/JingYenLoh"
-        },
-        {
-            "name": "Jackson Goode",
-            "url": "https://github.com/jacksongoode"
-        },
-        {
-            "name": "Lingfeng Zhang",
-            "url": "https://github.com/ccat3z"
-        },
-        {
-            "name": "Juan M. Cruz-Martinez",
-            "url": "https://github.com/scarlehoff"
-        },
-        {
-            "name": "Samuel Bachmann",
-            "url": "https://github.com/samuelba"
-        },
-        {
-            "name": "k-c13",
-            "url": "https://github.com/mokilcde"
-        },
-        {
-            "name": "Vicente Maroto Garzón",
-            "url": "https://github.com/C-512L"
-        },
-        {
-            "name": "luk",
-            "url": "https://github.com/thenameisluk"
-        }
-    ],
     "repository": {
         "type": "git",
         "url": "git+https://github.com/ddterm/gnome-shell-extension-ddterm.git"

--- a/package.json.license
+++ b/package.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Aleksandr Mezin <mezin.alexander@gmail.com>
+
+SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
`package.json` contains more metadata than necessary, so better avoid shipping it in the package.

`AUTHORS` file also supports comments - which is handy for multiple reasons.

https://docs.npmjs.com/cli/v11/configuring-npm/package-json#default-values