### PR TITLE
Revert "tests/wm: skip zero-monitor test on Fedora 41"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,16 +426,6 @@ def os_id(process_launcher):
 
 
 @pytest.fixture(scope='session')
-def os_version_id(process_launcher):
-    return process_launcher.run(
-        'sh',
-        '-c',
-        '. /etc/os-release && echo $VERSION_ID',
-        stdout=subprocess.PIPE
-    ).stdout.rstrip().decode()
-
-
-@pytest.fixture(scope='session')
 def sys_package(container, os_id, request):
     sys_package = request.config.option.sys_package
 

--- a/tests/test_wm.py
+++ b/tests/test_wm.py
@@ -929,11 +929,6 @@ class TestWaylandTwoMonitors(TestWayland):
 
 @pytest.mark.usefixtures('check_log')
 class TestWaylandNoMonitors(fixtures.GnomeSessionWaylandFixtures):
-    @pytest.fixture(scope='class', autouse=True)
-    def check_skip(self, os_version_id):
-        if os_version_id == '41':
-            pytest.skip('GNOME Shell with no monitors often crashes on Fedora 41')
-
     @pytest.fixture(scope='class')
     def initial_monitor_layout(self):
         return []


### PR DESCRIPTION
This reverts commit d4ac9641dbfb17de88830d8e466b655abf93b6bb.

It doesn't skip GNOME Shell startup - so does not solve the issue.