### PR TITLE
tests/wm: wait for `Meta.Display.grab-op-{begin,end}` signals

### DIFF
--- a/tests/dbus-interfaces/org.gnome.Shell.TestHook.xml
+++ b/tests/dbus-interfaces/org.gnome.Shell.TestHook.xml
@@ -71,6 +71,7 @@
         <property name="EnableAnimations" type="b" access="readwrite"/>
         <property name="ColorScheme" type="s" access="readwrite"/>
         <property name="AutoMaximizeWindows" type="b" access="readwrite"/>
+        <property name="GrabActive" type="b" access="readwrite"/>
 
         <signal name="WindowCreated"/>
         <signal name="WindowShown"/>

--- a/tests/shellhook.js
+++ b/tests/shellhook.js
@@ -82,6 +82,14 @@ const Interface = GObject.registerClass({
             }));
         });
 
+        this._connect_external(display, 'grab-op-begin', () => {
+            this.GrabActive = true;
+        });
+
+        this._connect_external(display, 'grab-op-end', () => {
+            this.GrabActive = false;
+        });
+
         this._connect_external(context, 'notify::unsafe-mode', () => {
             this.notify('UnsafeMode');
         });

--- a/tests/test_wm.py
+++ b/tests/test_wm.py
@@ -676,6 +676,7 @@ class CommonTests:
 
         try:
             shell_test_hook.mouse_down()
+            shell_test_hook.wait_property('GrabActive', True)
             extension_test_hook.wait_property(window_position.maximize_property, False)
 
             wait_idle()
@@ -692,6 +693,7 @@ class CommonTests:
 
         finally:
             shell_test_hook.mouse_up()
+            shell_test_hook.wait_property('GrabActive', False)
 
         wait_idle()
 


### PR DESCRIPTION
In mouse resizing test.