### PR TITLE
Remove stylesheet.css

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -163,8 +163,6 @@ subdir('schemas')
 subdir('ddterm')
 subdir('locale')
 
-pack += fs.copyfile('stylesheet.css', install: true, install_dir: extension_dir)
-
 pack_from_srcdir = [
   'LICENSES' / 'GPL-3.0-or-later.txt',
   'LICENSES' / 'CC0-1.0.txt',

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,9 +1,0 @@
-/*
- * SPDX-FileCopyrightText: 2024 Aleksandr Mezin <mezin.alexander@gmail.com>
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- */
-
-#ddterm-panel-icon > StIcon {
-    -st-icon-style: symbolic;
-}


### PR DESCRIPTION
We load the bundled icon by file name now, so the stylesheet does nothing.