### PR TITLE
Get rid of `gtk-builder-tool`, Xvfb for `meson test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
         if: ${{ !cancelled() && steps.pack.outcome == 'success' }}
 
       - name: Run checks
-        run: xvfb-run -d --server-args=-noreset --wait=0 -- meson test -v -j1
+        run: meson test -v -j1
         working-directory: build
         shell: pipetty bash -e {0}
         if: ${{ !cancelled() && steps.pack.outcome == 'success' }}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,7 +13,7 @@ conflicts=('gnome-shell-extension-ddterm')
 provides=('gnome-shell-extension-ddterm')
 depends=('gjs' 'gtk3' 'vte3' 'libhandy')
 makedepends=('meson' 'git')
-checkdepends=('python-pytest' 'python-gobject' 'gnome-shell' 'wl-clipboard' 'xorg-server-xvfb')
+checkdepends=('python-pytest' 'python-gobject' 'gnome-shell' 'wl-clipboard')
 
 # Skipping source=() completely, using startdir instead
 # https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/master/PKGBUILD
@@ -37,7 +37,7 @@ build() {
 
     local meson_options=(
         "-Dtests=$tests_feature"
-        "-Dtests_x11=$tests_feature"
+        -Dtests_x11=disabled
         "-Dtests_wl_clipboard=$tests_feature"
         -Dtypelib_installer=false
     )
@@ -47,7 +47,7 @@ build() {
 }
 
 check() {
-    LIBGL_ALWAYS_SOFTWARE=1 xvfb-run --auto-display --server-args=-noreset --wait=0 -- meson test -C build --print-errorlogs
+    meson test -C build --print-errorlogs
 }
 
 package() {

--- a/ddterm/app/ui/meson.build
+++ b/ddterm/app/ui/meson.build
@@ -10,11 +10,4 @@ foreach app_ui_src_file : app_ui_src_files
     install: true,
     install_dir: extension_dir / 'ddterm' / 'app' / 'ui',
   )
-
-  test(
-    fs.relative_to(app_ui_src_file, meson.project_source_root()),
-    gtk3_builder_tool,
-    args: ['validate', app_ui_src_file],
-    suite: ['gtk-builder-validate'],
-  )
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,6 @@ summary(
   section: 'System-wide installation',
 )
 
-gtk3_builder_tool = find_program('gtk-builder-tool')
 glib_compile_schemas_tool = find_program('glib-compile-schemas')
 
 xgettext = find_program('xgettext', required: false, disabler: true)

--- a/meson.build
+++ b/meson.build
@@ -60,9 +60,6 @@ summary(
   section: 'System-wide installation',
 )
 
-# Meson's "capture: true" hides stderr output (warnings from gtk-builder-tool)
-capture_stdout = ['sh', '-c', 'exec "$@" >"$0"', '@OUTPUT@']
-
 gtk3_builder_tool = find_program('gtk-builder-tool')
 glib_compile_schemas_tool = find_program('glib-compile-schemas')
 


### PR DESCRIPTION
No need to run `meson test` under Xvfb anymore