### PR TITLE
prefs/shortcuts: reject more invalid keybindings

### DIFF
--- a/ddterm/pref/shortcuts.js
+++ b/ddterm/pref/shortcuts.js
@@ -93,6 +93,45 @@ function normalize_keyval_and_mask(display, keycode, mask, group) {
     return [unmodified_keyval, mask & explicit_modifiers];
 }
 
+const FORBIDDEN_KEYVALS = [
+    /* Navigation keys */
+    Gdk.KEY_Home,
+    Gdk.KEY_Left,
+    Gdk.KEY_Up,
+    Gdk.KEY_Right,
+    Gdk.KEY_Down,
+    Gdk.KEY_Page_Up,
+    Gdk.KEY_Page_Down,
+    Gdk.KEY_End,
+    Gdk.KEY_Tab,
+
+    /* Return */
+    Gdk.KEY_KP_Enter,
+    Gdk.KEY_Return,
+
+    Gdk.KEY_Mode_switch,
+];
+
+function is_valid_binding(keyval, mask) {
+    if (mask && mask !== Gdk.ModifierType.SHIFT_MASK)
+        return true;
+
+    return !(
+        (keyval >= Gdk.KEY_a && keyval <= Gdk.KEY_z) ||
+        (keyval >= Gdk.KEY_A && keyval <= Gdk.KEY_Z) ||
+        (keyval >= Gdk.KEY_0 && keyval <= Gdk.KEY_9) ||
+        (keyval >= Gdk.KEY_kana_fullstop && keyval <= Gdk.KEY_semivoicedsound) ||
+        (keyval >= Gdk.KEY_Arabic_comma && keyval <= Gdk.KEY_Arabic_sukun) ||
+        (keyval >= Gdk.KEY_Serbian_dje && keyval <= Gdk.KEY_Cyrillic_HARDSIGN) ||
+        (keyval >= Gdk.KEY_Greek_ALPHAaccent && keyval <= Gdk.KEY_Greek_omega) ||
+        (keyval >= Gdk.KEY_hebrew_doublelowline && keyval <= Gdk.KEY_hebrew_taf) ||
+        (keyval >= Gdk.KEY_Thai_kokai && keyval <= Gdk.KEY_Thai_lekkao) ||
+        (keyval >= Gdk.KEY_Hangul_Kiyeog && keyval <= Gdk.KEY_Hangul_J_YeorinHieuh) ||
+        (keyval === Gdk.KEY_space && !mask) ||
+        FORBIDDEN_KEYVALS.includes(keyval)
+    );
+}
+
 class ShortcutEditDialog extends Gtk.Dialog {
     static [GObject.GTypeName] = 'DDTermShortcutEditDialog';
 
@@ -233,6 +272,9 @@ class ShortcutEditDialog extends Gtk.Dialog {
         this.#update_accelerator(keyval_lower, real_mask);
 
         if (!Gtk.accelerator_valid(keyval_lower, real_mask))
+            return;
+
+        if (!is_valid_binding(keyval_lower, real_mask))
             return;
 
         this.emit('stopped');


### PR DESCRIPTION
Reject keybindings that could cause issues when typing text, don't override standard keyboard navigation bindings.

Copy the validation logic from GNOME Control Center.