### PR TITLE
ci: fix reruns of `pages` job

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          pattern: '!{bundle,github-pages}'
+          pattern: '!{bundle,github-pages-*}'
 
       - run: >-
           find . -type d -exec
@@ -52,9 +52,12 @@ jobs:
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: .
+          name: github-pages-${{ github.run_attempt }}
 
       - id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}
 
   release:
     needs: ci


### PR DESCRIPTION
Rerunning `pages` job creates another `github-pages` artifact every time, for the same workflow run.

`actions/deploy-pages` accepts only artifact name, not id. When it finds multiple artifacts with the same name, it fails.

Append rerun counter to the end of the artifact name to make the name unique.