### PR TITLE
meson: simplify `makezip.py` CLI

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -163,22 +163,33 @@ subdir('schemas')
 subdir('ddterm')
 subdir('locale')
 
-bundle_from_srcdir = [
+bundle_from_srcdir = files(
   'LICENSES' / 'GPL-3.0-or-later.txt',
   'LICENSES' / 'CC0-1.0.txt',
   'LICENSES' / 'MIT.txt',
   'REUSE.toml',
-]
+)
 
 bundle_command = [make_zip_command]
 
-foreach extra_path : bundle_from_srcdir
-  bundle_command += ['--include', files(extra_path), extra_path]
+foreach bundle_entry : bundle
+  bundle_command += [
+    '--entry',
+    bundle_entry,
+    fs.relative_to(bundle_entry, meson.current_build_dir()),
+  ]
+endforeach
+
+foreach bundle_entry : bundle_from_srcdir
+  bundle_command += [
+    '--entry',
+    bundle_entry,
+    fs.relative_to(bundle_entry, meson.current_source_dir()),
+  ]
 endforeach
 
 bundle_target = custom_target(
   command: bundle_command,
-  input: bundle,
   output: f'@uuid@.shell-extension.zip',
   build_by_default: true,
 )

--- a/tools/makezip.py
+++ b/tools/makezip.py
@@ -4,35 +4,42 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+"""
+Create a zip archive from a list of files and their target names/paths within
+the archive.
+"""
+
 import argparse
-import os.path
 import pathlib
 import zipfile
 
 
-def makezip(output, inputs, include, relative_to):
-    inputs = [pathlib.Path(os.path.abspath(p)) for p in inputs]
-    relative_to = pathlib.Path(os.path.abspath(relative_to))
-
+def makezip(output, entries):
     with zipfile.ZipFile(
         output,
         mode='w',
         compression=zipfile.ZIP_DEFLATED,
         compresslevel=9,
     ) as out:
-        for infile in inputs:
-            out.write(infile, arcname=infile.relative_to(relative_to).as_posix())
-
-        for infile, arcname in include:
+        for infile, arcname in entries:
             out.write(infile, arcname=arcname.as_posix())
 
 
 def cli(*args, **kwargs):
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--relative-to', type=pathlib.Path, default=pathlib.Path.cwd())
-    parser.add_argument('--output', type=pathlib.Path, required=True)
-    parser.add_argument('--include', type=pathlib.Path, nargs=2, default=[], action='append')
-    parser.add_argument('inputs', type=pathlib.Path, nargs='+')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', '-o', type=pathlib.Path, required=True)
+
+    parser.add_argument(
+        '--entry',
+        '-e',
+        dest='entries',
+        metavar=('FILE', 'ENTRY_NAME'),
+        type=pathlib.Path,
+        nargs=2,
+        default=[],
+        action='append',
+        required=True,
+    )
 
     makezip(**vars(parser.parse_args(*args, **kwargs)))
 

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -6,9 +6,6 @@ make_zip_command = [
   find_program(files('makezip.py')),  # https://github.com/mesonbuild/meson/issues/11255
   '--output',
   '@OUTPUT@',
-  '--relative-to',
-  '@OUTDIR@',
-  '@INPUT@',
 ]
 
 fix_metadata_command = [


### PR DESCRIPTION
Generate all archive entry names on Meson side. Easier to understand, more flexible.