### PR TITLE
Improve `gjs-typelib-installer` stub

### DIFF
--- a/ddterm/util/gjs-typelib-installer.js
+++ b/ddterm/util/gjs-typelib-installer.js
@@ -4,15 +4,37 @@
 
 import Gi from 'gi';
 
-// Stub
+// Minimal stub for https://github.com/ddterm/gjs-typelib-installer,
+// used when the subproject is disabled (-Dtypelib_installer=false).
 
 export function require(versions) {
-    return Object.entries(versions).map(
-        ([name, version]) => Gi.require(name, version)
-    );
+    const found = {};
+    const missing = new Set();
+
+    for (const [name, version] of Object.entries(versions)) {
+        try {
+            found[name] = Gi.require(name, version);
+        } catch (error) {
+            logError(error);
+            missing.add(`${name}-${version}.typelib`);
+        }
+    }
+
+    if (missing.size > 0)
+        throw new MissingDependencies(missing);
+
+    return found;
 }
 
-export class MissingDependencies extends Error {}
+export class MissingDependencies extends Error {
+    constructor(files) {
+        super(`Missing typelib files: ${Array.from(files).join(', ')}.`);
+
+        this.name = 'MissingDependencies';
+        this.packages = new Set();
+        this.files = new Set(files);
+    }
+}
 
 export function findTerminalInstallCommand() {
     return null;


### PR DESCRIPTION
Implement just enough logic to show the error message correctly.

Fix `require()` return type to match real `gjs-typelib-installer` implementation.