### PR TITLE
settings: hide the window when losing focus by default

### DIFF
--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -174,7 +174,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
       <default>true</default>
     </key>
     <key name="hide-when-focus-lost" type="b">
-      <default>false</default>
+      <default>true</default>
     </key>
     <key name="pointer-autohide" type="b">
       <default>false</default>


### PR DESCRIPTION
I've been using it for long time with no issues, and it provides a better experience when, for example, clicking on hyperlinks.