### PR TITLE
prefs/positionsize: remove trailing colons

### DIFF
--- a/ddterm/pref/positionsize.js
+++ b/ddterm/pref/positionsize.js
@@ -211,7 +211,7 @@ export class PositionSizeGroup extends PreferencesGroup {
         bind_model_to_list_store(this.monitors, extended_monitors);
 
         const monitor_combo = new ComboRow({
-            title: this.gettext('On _monitor:'),
+            title: this.gettext('On _monitor'),
             visible: true,
             use_underline: true,
             use_subtitle: true,
@@ -271,7 +271,7 @@ export class PositionSizeGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'window-position',
-            title: this.gettext('_Window position:'),
+            title: this.gettext('_Window position'),
             model: {
                 top: this.gettext('Top'),
                 bottom: this.gettext('Bottom'),
@@ -299,7 +299,7 @@ export class PositionSizeGroup extends PreferencesGroup {
             round_digits: 2,
             visible: true,
             use_underline: true,
-            title: this.gettext('Window _size:'),
+            title: this.gettext('Window _size'),
         });
 
         const percent_format = new Intl.NumberFormat(undefined, { style: 'percent' });

--- a/po/cs.po
+++ b/po/cs.po
@@ -825,12 +825,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "Na monitoru se zaměřením klávesnice"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "Na _monitoru:"
+msgid "On _monitor"
+msgstr "Na _monitoru"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "Pozice _Okna:"
+msgid "_Window position"
+msgstr "Pozice _Okna"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -849,8 +849,8 @@ msgid "Right"
 msgstr "Vpravo"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "_Velikost okna:"
+msgid "Window _size"
+msgstr "_Velikost okna"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/ddterm@amezin.github.com.pot
+++ b/po/ddterm@amezin.github.com.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ddterm@amezin.github.com\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-22 13:28+0000\n"
+"POT-Creation-Date: 2026-02-05 03:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -822,11 +822,11 @@ msgid "On the monitor with keyboard focus"
 msgstr ""
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
+msgid "On _monitor"
 msgstr ""
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
+msgid "_Window position"
 msgstr ""
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
@@ -846,7 +846,7 @@ msgid "Right"
 msgstr ""
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
+msgid "Window _size"
 msgstr ""
 
 #: ddterm/pref/scrolling.js:24

--- a/po/de.po
+++ b/po/de.po
@@ -830,12 +830,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "Auf dem Monitor mit Eingabefokus"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "Auf _Monitor:"
+msgid "On _monitor"
+msgstr "Auf _Monitor"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "Fensterposition:"
+msgid "_Window position"
+msgstr "Fensterposition"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -854,8 +854,8 @@ msgid "Right"
 msgstr "Rechts"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Fen_stergröße:"
+msgid "Window _size"
+msgstr "Fen_stergröße"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/el.po
+++ b/po/el.po
@@ -836,11 +836,11 @@ msgid "On the monitor with keyboard focus"
 msgstr "Στην οθόνη του πληκτρολόγιου"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
+msgid "On _monitor"
 msgstr "Στην οθόνη"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
+msgid "_Window position"
 msgstr "Θέση Παραθύρου"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
@@ -860,8 +860,8 @@ msgid "Right"
 msgstr "Δεξιά"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Μέγεθος παραθύρου:"
+msgid "Window _size"
+msgstr "Μέγεθος παραθύρου"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/eo.po
+++ b/po/eo.po
@@ -826,12 +826,12 @@ msgid "On the monitor with keyboard focus"
 msgstr ""
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
+msgid "On _monitor"
 msgstr ""
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "_Fenestra pozicio:"
+msgid "_Window position"
+msgstr "_Fenestra pozicio"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -850,8 +850,8 @@ msgid "Right"
 msgstr "Dekstro"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Fenestra _grando:"
+msgid "Window _size"
+msgstr "Fenestra _grando"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/es.po
+++ b/po/es.po
@@ -833,12 +833,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "En el monitor con teclado focus"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "En el _monitor:"
+msgid "On _monitor"
+msgstr "En el _monitor"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "_Posición de la ventana:"
+msgid "_Window position"
+msgstr "_Posición de la ventana"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -857,8 +857,8 @@ msgid "Right"
 msgstr "Derecha"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Tamaño de la _ventana:"
+msgid "Window _size"
+msgstr "Tamaño de la _ventana"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/fr.po
+++ b/po/fr.po
@@ -835,12 +835,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "Sur l'écran avec le focus clavier"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "Sur l'écran :"
+msgid "On _monitor"
+msgstr "Sur l'écran"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "Position de la fenêtre :"
+msgid "_Window position"
+msgstr "Position de la fenêtre"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -859,8 +859,8 @@ msgid "Right"
 msgstr "Droite"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Taille de la fenêtre :"
+msgid "Window _size"
+msgstr "Taille de la fenêtre"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/it.po
+++ b/po/it.po
@@ -834,12 +834,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "Sul monitor con la tastiera focus"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "Sul _monitor:"
+msgid "On _monitor"
+msgstr "Sul _monitor"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "_Posizione della finestra:"
+msgid "_Window position"
+msgstr "_Posizione della finestra"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -858,8 +858,8 @@ msgid "Right"
 msgstr "A destra"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Dimensione finestra:"
+msgid "Window _size"
+msgstr "Dimensione finestra"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -825,12 +825,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "På skjermen med tastaturfokus"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "På _skjerm:"
+msgid "On _monitor"
+msgstr "På _skjerm"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "_Vindusposisjon:"
+msgid "_Window position"
+msgstr "_Vindusposisjon"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -849,8 +849,8 @@ msgid "Right"
 msgstr "Høyre"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Vindus_størrelse:"
+msgid "Window _size"
+msgstr "Vindus_størrelse"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/pl.po
+++ b/po/pl.po
@@ -838,12 +838,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "Na monitorze z klawiaturą aktywną"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "Na _monitorze:"
+msgid "On _monitor"
+msgstr "Na _monitorze"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "Pozycja _okna:"
+msgid "_Window position"
+msgstr "Pozycja _okna"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -862,8 +862,8 @@ msgid "Right"
 msgstr "Prawo"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "_Rozmiar okna:"
+msgid "Window _size"
+msgstr "_Rozmiar okna"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/pt.po
+++ b/po/pt.po
@@ -833,12 +833,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "No monitor com o foco para digitação"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "No monitor:"
+msgid "On _monitor"
+msgstr "No monitor"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "Posição da janela:"
+msgid "_Window position"
+msgstr "Posição da janela"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -857,8 +857,8 @@ msgid "Right"
 msgstr "Direita"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Tamanho da janela:"
+msgid "Window _size"
+msgstr "Tamanho da janela"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/ru.po
+++ b/po/ru.po
@@ -834,12 +834,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "На мониторе с фокусом ввода с клавиатуры"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "На мониторе:"
+msgid "On _monitor"
+msgstr "На мониторе"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "Положение окна:"
+msgid "_Window position"
+msgstr "Положение окна"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -858,8 +858,8 @@ msgid "Right"
 msgstr "Справа"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Размер окна:"
+msgid "Window _size"
+msgstr "Размер окна"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/tr.po
+++ b/po/tr.po
@@ -831,12 +831,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "Klavye odağının bulunduğu monitörde"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "_Monitörde:"
+msgid "On _monitor"
+msgstr "_Monitörde"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "_Pencere konumu:"
+msgid "_Window position"
+msgstr "_Pencere konumu"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -855,8 +855,8 @@ msgid "Right"
 msgstr "Sağ"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "Pencere _boyutu:"
+msgid "Window _size"
+msgstr "Pencere _boyutu"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -824,12 +824,12 @@ msgid "On the monitor with keyboard focus"
 msgstr "在键盘 聚焦的显示器上"
 
 #: ddterm/pref/positionsize.js:214
-msgid "On _monitor:"
-msgstr "在 _显示器上："
+msgid "On _monitor"
+msgstr "在 _显示器上"
 
 #: ddterm/pref/positionsize.js:274
-msgid "_Window position:"
-msgstr "_窗口位置："
+msgid "_Window position"
+msgstr "_窗口位置"
 
 #: ddterm/pref/positionsize.js:276 ddterm/pref/tabs.js:43
 msgid "Top"
@@ -848,8 +848,8 @@ msgid "Right"
 msgstr "右边"
 
 #: ddterm/pref/positionsize.js:302
-msgid "Window _size:"
-msgstr "窗口 _大小："
+msgid "Window _size"
+msgstr "窗口 _大小"
 
 #: ddterm/pref/scrolling.js:24
 msgid "Scrolling"


### PR DESCRIPTION
`PreferencesRow` `title` shouldn't end with `:`.