### PR TITLE
prefs/animation: remove trailing colons

### DIFF
--- a/ddterm/pref/animation.js
+++ b/ddterm/pref/animation.js
@@ -100,7 +100,7 @@ export class AnimationGroup extends PreferencesGroup {
 
         this.#show_animation_combo = this.add_combo_text_row({
             key: 'show-animation',
-            title: this.gettext('_Show animation:'),
+            title: this.gettext('_Show animation'),
             model: animations,
             flags: Gio.SettingsBindFlags.NO_SENSITIVITY,
         });
@@ -111,7 +111,7 @@ export class AnimationGroup extends PreferencesGroup {
             round_digits: 2,
             visible: true,
             use_underline: true,
-            title: this.gettext('_Show animation duration:'),
+            title: this.gettext('_Show animation duration'),
         });
 
         this.settings.bind_writable(
@@ -125,7 +125,7 @@ export class AnimationGroup extends PreferencesGroup {
 
         this.#hide_animation_combo = this.add_combo_text_row({
             key: 'hide-animation',
-            title: this.gettext('_Hide animation:'),
+            title: this.gettext('_Hide animation'),
             model: animations,
             flags: Gio.SettingsBindFlags.NO_SENSITIVITY,
         });
@@ -136,7 +136,7 @@ export class AnimationGroup extends PreferencesGroup {
             round_digits: 2,
             visible: true,
             use_underline: true,
-            title: this.gettext('_Hide animation duration:'),
+            title: this.gettext('_Hide animation duration'),
         });
 
         this.settings.bind_writable(

--- a/po/cs.po
+++ b/po/cs.po
@@ -529,20 +529,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Exponenciálně klesající parabolické (odrazové) prolínání s odrazem na obou koncích"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_Zobrazit animaci:"
+msgid "_Show animation"
+msgstr "_Zobrazit animaci"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "_Doba po kterou bude animace zobrazena:"
+msgid "_Show animation duration"
+msgstr "_Doba po kterou bude animace zobrazena"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_Skrýt animaci:"
+msgid "_Hide animation"
+msgstr "_Skrýt animaci"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "_Doba po kterou bude animace skryta:"
+msgid "_Hide animation duration"
+msgstr "_Doba po kterou bude animace skryta"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/ddterm@amezin.github.com.pot
+++ b/po/ddterm@amezin.github.com.pot
@@ -528,19 +528,19 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr ""
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
+msgid "_Show animation"
 msgstr ""
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
+msgid "_Show animation duration"
 msgstr ""
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
+msgid "_Hide animation"
 msgstr ""
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
+msgid "_Hide animation duration"
 msgstr ""
 
 #: ddterm/pref/behavior.js:19

--- a/po/de.po
+++ b/po/de.po
@@ -534,20 +534,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Exponentiell abklingend, geschwungen, mit Sprung an Anfang und Ende"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "Animation beim Anzeigen:"
+msgid "_Show animation"
+msgstr "Animation beim Anzeigen"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "Dauer der Animation beim Anzeigen:"
+msgid "_Show animation duration"
+msgstr "Dauer der Animation beim Anzeigen"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "Animation beim Ausblenden:"
+msgid "_Hide animation"
+msgstr "Animation beim Ausblenden"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "Dauer der Animation beim Ausblenden:"
+msgid "_Hide animation duration"
+msgstr "Dauer der Animation beim Ausblenden"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/el.po
+++ b/po/el.po
@@ -540,20 +540,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr ""
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_Εμφάνιση κινούμενων εικόνων:"
+msgid "_Show animation"
+msgstr "_Εμφάνιση κινούμενων εικόνων"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "_Εμφάνιση διάρκειας κινούμενης εικόνας:"
+msgid "_Show animation duration"
+msgstr "_Εμφάνιση διάρκειας κινούμενης εικόνας"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_Απόκρυψη κινούμενων εικόνων:"
+msgid "_Hide animation"
+msgstr "_Απόκρυψη κινούμενων εικόνων"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "_Απόκρυψη διάρκειας κινούμενης εικόνας:"
+msgid "_Hide animation duration"
+msgstr "_Απόκρυψη διάρκειας κινούμενης εικόνας"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/eo.po
+++ b/po/eo.po
@@ -532,19 +532,19 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr ""
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
+msgid "_Show animation"
 msgstr ""
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
+msgid "_Show animation duration"
 msgstr ""
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
+msgid "_Hide animation"
 msgstr ""
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
+msgid "_Hide animation duration"
 msgstr ""
 
 #: ddterm/pref/behavior.js:19

--- a/po/es.po
+++ b/po/es.po
@@ -537,20 +537,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Intercalación parabólica (rebote) con decaimiento exponencial, con rebote en ambos extremos"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_Mostrar animación:"
+msgid "_Show animation"
+msgstr "_Mostrar animación"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "_Mostrar duración de la animación:"
+msgid "_Show animation duration"
+msgstr "_Mostrar duración de la animación"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_Ocultar animación:"
+msgid "_Hide animation"
+msgstr "_Ocultar animación"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "_Duración de la animación de ocultar:"
+msgid "_Hide animation duration"
+msgstr "_Duración de la animación de ocultar"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/fr.po
+++ b/po/fr.po
@@ -539,20 +539,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Tweening rebonbissant avec rebond aux deux extrémités"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "Animation d'apparition :"
+msgid "_Show animation"
+msgstr "Animation d'apparition"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "Durée de l'animation de disparition :"
+msgid "_Show animation duration"
+msgstr "Durée de l'animation de disparition"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "Animation de disparition :"
+msgid "_Hide animation"
+msgstr "Animation de disparition"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "Durée de l'animation d'apparition :"
+msgid "_Hide animation duration"
+msgstr "Durée de l'animation d'apparition"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/it.po
+++ b/po/it.po
@@ -538,20 +538,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Tweening parabolico (rimbalzo) a decadimento esponenziale, con rimbalzo su entrambe le estremità"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_Mostra animazione:"
+msgid "_Show animation"
+msgstr "_Mostra animazione"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "_Mostra durata animazione:"
+msgid "_Show animation duration"
+msgstr "_Mostra durata animazione"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_Nascondere l'animazione:"
+msgid "_Hide animation"
+msgstr "_Nascondere l'animazione"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "_Nascondere la durata dell'animazione:"
+msgid "_Hide animation duration"
+msgstr "_Nascondere la durata dell'animazione"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -529,20 +529,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Eksponentielt avtagende parabolisk (sprett-) mellomtegning, med sprett i begge ender"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_Vis animasjon:"
+msgid "_Show animation"
+msgstr "_Vis animasjon"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "_Vis animasjonsvarighet:"
+msgid "_Show animation duration"
+msgstr "_Vis animasjonsvarighet"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_Skjul animasjon:"
+msgid "_Hide animation"
+msgstr "_Skjul animasjon"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "_Skjul animasjonsvarighet:"
+msgid "_Hide animation duration"
+msgstr "_Skjul animasjonsvarighet"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/pl.po
+++ b/po/pl.po
@@ -542,20 +542,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Wykładniczo zanikająca animacja paraboliczna (odbicia), z odbiciem na obu końcach"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_Pokaż animację:"
+msgid "_Show animation"
+msgstr "_Pokaż animację"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "Czas trwania animacji _pokazywania:"
+msgid "_Show animation duration"
+msgstr "Czas trwania animacji _pokazywania"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_Ukryj animację:"
+msgid "_Hide animation"
+msgstr "_Ukryj animację"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "Czas trwania animacji _ukrywania:"
+msgid "_Hide animation duration"
+msgstr "Czas trwania animacji _ukrywania"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/pt.po
+++ b/po/pt.po
@@ -537,20 +537,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Tweening de parabólica exponencialmente decadente, com quicada em ambos os lados"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_Animação de mostrar:"
+msgid "_Show animation"
+msgstr "_Animação de mostrar"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "_Duração da animação de mostrar:"
+msgid "_Show animation duration"
+msgstr "_Duração da animação de mostrar"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_Animação de recolher:"
+msgid "_Hide animation"
+msgstr "_Animação de recolher"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "_Duração da animação de recolher:"
+msgid "_Hide animation duration"
+msgstr "_Duração da animação de recolher"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/ru.po
+++ b/po/ru.po
@@ -538,20 +538,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Экспоненциально затухающая параболическая с отскоком в начале и конце"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "Анимация открытия:"
+msgid "_Show animation"
+msgstr "Анимация открытия"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "Длительность анимации открытия:"
+msgid "_Show animation duration"
+msgstr "Длительность анимации открытия"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "Анимация закрытия:"
+msgid "_Hide animation"
+msgstr "Анимация закрытия"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "Длительность анимации закрытия:"
+msgid "_Hide animation duration"
+msgstr "Длительность анимации закрытия"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/tr.po
+++ b/po/tr.po
@@ -535,20 +535,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "Her iki tarafta sıçrama ile üstel olarak azalan parabolik (sıçrama) ara doldurma"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_Animasyonu göster:"
+msgid "_Show animation"
+msgstr "_Animasyonu göster"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "_Gösterme animasyonu süresi:"
+msgid "_Show animation duration"
+msgstr "_Gösterme animasyonu süresi"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_Animasyonu gizle:"
+msgid "_Hide animation"
+msgstr "_Animasyonu gizle"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "_Gizleme animasyonu süresi:"
+msgid "_Hide animation duration"
+msgstr "_Gizleme animasyonu süresi"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -528,20 +528,20 @@ msgid "Exponentially decaying parabolic (bounce) tweening, with bounce on both e
 msgstr "指数衰减抛物线(弹跳)渐变，两端都有弹跳"
 
 #: ddterm/pref/animation.js:103
-msgid "_Show animation:"
-msgstr "_展示动画："
+msgid "_Show animation"
+msgstr "_展示动画"
 
 #: ddterm/pref/animation.js:114
-msgid "_Show animation duration:"
-msgstr "_显示动画持续时间："
+msgid "_Show animation duration"
+msgstr "_显示动画持续时间"
 
 #: ddterm/pref/animation.js:128
-msgid "_Hide animation:"
-msgstr "_隐藏动画："
+msgid "_Hide animation"
+msgstr "_隐藏动画"
 
 #: ddterm/pref/animation.js:139
-msgid "_Hide animation duration:"
-msgstr "_隐藏动画持续时间："
+msgid "_Hide animation duration"
+msgstr "_隐藏动画持续时间"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"


### PR DESCRIPTION
`PreferencesRow` `title` should not end with `:`.