### PR TITLE
prefs/tabs: remove trailing colons

### DIFF
--- a/ddterm/pref/tabs.js
+++ b/ddterm/pref/tabs.js
@@ -27,7 +27,7 @@ export class TabsGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'tab-policy',
-            title: this.gettext('Show tab _bar:'),
+            title: this.gettext('Show tab _bar'),
             model: {
                 always: this.gettext('Always'),
                 automatic: this.gettext('Automatic'),
@@ -37,7 +37,7 @@ export class TabsGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'tab-position',
-            title: this.gettext('Tab bar position:'),
+            title: this.gettext('Tab bar position'),
             model: {
                 bottom: this.gettext('Bottom'),
                 top: this.gettext('Top'),
@@ -48,7 +48,7 @@ export class TabsGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'tab-label-ellipsize-mode',
-            title: this.gettext('Ellipsize tab labels:'),
+            title: this.gettext('Ellipsize tab labels'),
             model: {
                 none: this.gettext('None'),
                 start: this.gettext('Start'),
@@ -76,7 +76,7 @@ export class TabsGroup extends PreferencesGroup {
             round_digits: 2,
             visible: true,
             use_underline: true,
-            title: this.gettext('Tab width:'),
+            title: this.gettext('Tab width'),
         });
 
         const percent_format = new Intl.NumberFormat(undefined, { style: 'percent' });

--- a/po/cs.po
+++ b/po/cs.po
@@ -1046,8 +1046,8 @@ msgid "_Restore previous tabs on startup"
 msgstr ""
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Zobrazit _panel karet:"
+msgid "Show tab _bar"
+msgstr "Zobrazit _panel karet"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1058,12 +1058,12 @@ msgid "Never"
 msgstr "Nikdy"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Pozice panelu karet:"
+msgid "Tab bar position"
+msgstr "Pozice panelu karet"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Zkrátit názvy panelů:"
+msgid "Ellipsize tab labels"
+msgstr "Zkrátit názvy panelů"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1078,8 +1078,8 @@ msgid "End"
 msgstr "Konec"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Šířka panelu:"
+msgid "Tab width"
+msgstr "Šířka panelu"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/ddterm@amezin.github.com.pot
+++ b/po/ddterm@amezin.github.com.pot
@@ -1030,7 +1030,7 @@ msgid "_Restore previous tabs on startup"
 msgstr ""
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
+msgid "Show tab _bar"
 msgstr ""
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
@@ -1042,11 +1042,11 @@ msgid "Never"
 msgstr ""
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
+msgid "Tab bar position"
 msgstr ""
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
+msgid "Ellipsize tab labels"
 msgstr ""
 
 #: ddterm/pref/tabs.js:54
@@ -1062,7 +1062,7 @@ msgid "End"
 msgstr ""
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
+msgid "Tab width"
 msgstr ""
 
 #: ddterm/pref/tabs.js:96

--- a/po/de.po
+++ b/po/de.po
@@ -1039,8 +1039,8 @@ msgid "_Restore previous tabs on startup"
 msgstr "_Vorherige Reiter beim Start wiederherstellen"
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Reiter_leiste anzeigen:"
+msgid "Show tab _bar"
+msgstr "Reiter_leiste anzeigen"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1051,12 +1051,12 @@ msgid "Never"
 msgstr "Niemals"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Position der Reiterleiste:"
+msgid "Tab bar position"
+msgstr "Position der Reiterleiste"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Reitertitel kürzen:"
+msgid "Ellipsize tab labels"
+msgstr "Reitertitel kürzen"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1071,8 +1071,8 @@ msgid "End"
 msgstr "Ende"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Reiterbreite:"
+msgid "Tab width"
+msgstr "Reiterbreite"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/el.po
+++ b/po/el.po
@@ -1059,8 +1059,8 @@ msgid "_Restore previous tabs on startup"
 msgstr ""
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Εμφάνιση μπάρας καρτελών:"
+msgid "Show tab _bar"
+msgstr "Εμφάνιση μπάρας καρτελών"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1071,11 +1071,11 @@ msgid "Never"
 msgstr "Ποτέ"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Θέση μπάρας καρτελών:"
+msgid "Tab bar position"
+msgstr "Θέση μπάρας καρτελών"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
+msgid "Ellipsize tab labels"
 msgstr ""
 
 #: ddterm/pref/tabs.js:54
@@ -1091,8 +1091,8 @@ msgid "End"
 msgstr "Τέλος"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Πλάτος καρτέλας:"
+msgid "Tab width"
+msgstr "Πλάτος καρτέλας"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/eo.po
+++ b/po/eo.po
@@ -1038,7 +1038,7 @@ msgid "_Restore previous tabs on startup"
 msgstr ""
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
+msgid "Show tab _bar"
 msgstr ""
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
@@ -1050,11 +1050,11 @@ msgid "Never"
 msgstr "Neniam"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
+msgid "Tab bar position"
 msgstr ""
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
+msgid "Ellipsize tab labels"
 msgstr ""
 
 #: ddterm/pref/tabs.js:54
@@ -1070,7 +1070,7 @@ msgid "End"
 msgstr "Fino"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
+msgid "Tab width"
 msgstr ""
 
 #: ddterm/pref/tabs.js:96

--- a/po/es.po
+++ b/po/es.po
@@ -1041,8 +1041,8 @@ msgid "_Restore previous tabs on startup"
 msgstr "_Restaurar pestañas anteriores al iniciar"
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Mostrar la _barra de pestañas:"
+msgid "Show tab _bar"
+msgstr "Mostrar la _barra de pestañas"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1053,12 +1053,12 @@ msgid "Never"
 msgstr "Nunca"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Posición de las pestañas:"
+msgid "Tab bar position"
+msgstr "Posición de las pestañas"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Etiquetas de tarjetas en forma de elipse:"
+msgid "Ellipsize tab labels"
+msgstr "Etiquetas de tarjetas en forma de elipse"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1073,8 +1073,8 @@ msgid "End"
 msgstr "Fin"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Ancho de la pestaña:"
+msgid "Tab width"
+msgstr "Ancho de la pestaña"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1053,8 +1053,8 @@ msgid "_Restore previous tabs on startup"
 msgstr ""
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Afficher la barre d'onglets :"
+msgid "Show tab _bar"
+msgstr "Afficher la barre d'onglets"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1065,12 +1065,12 @@ msgid "Never"
 msgstr "Jamais"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Position de la barre d'onglets :"
+msgid "Tab bar position"
+msgstr "Position de la barre d'onglets"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Raccourcir les noms d'onglets :"
+msgid "Ellipsize tab labels"
+msgstr "Raccourcir les noms d'onglets"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1085,8 +1085,8 @@ msgid "End"
 msgstr "Fin"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Largeur des onglets :"
+msgid "Tab width"
+msgstr "Largeur des onglets"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/it.po
+++ b/po/it.po
@@ -1052,8 +1052,8 @@ msgid "_Restore previous tabs on startup"
 msgstr ""
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Mostra la barra delle schede:"
+msgid "Show tab _bar"
+msgstr "Mostra la barra delle schede"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1064,12 +1064,12 @@ msgid "Never"
 msgstr "Mai"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Posizione della barra delle schede:"
+msgid "Tab bar position"
+msgstr "Posizione della barra delle schede"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Etichette delle schede a forma di ellisse:"
+msgid "Ellipsize tab labels"
+msgstr "Etichette delle schede a forma di ellisse"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1084,8 +1084,8 @@ msgid "End"
 msgstr "Fine"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Larghezza scheda:"
+msgid "Tab width"
+msgstr "Larghezza scheda"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -1044,8 +1044,8 @@ msgid "_Restore previous tabs on startup"
 msgstr ""
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Vis fane_felt:"
+msgid "Show tab _bar"
+msgstr "Vis fane_felt"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1056,12 +1056,12 @@ msgid "Never"
 msgstr "Aldri"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Fanefeltsposisjon:"
+msgid "Tab bar position"
+msgstr "Fanefeltsposisjon"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Elliptiser faneetiketter:"
+msgid "Ellipsize tab labels"
+msgstr "Elliptiser faneetiketter"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1076,8 +1076,8 @@ msgid "End"
 msgstr "Slutten"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Fanebredde:"
+msgid "Tab width"
+msgstr "Fanebredde"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1056,8 +1056,8 @@ msgid "_Restore previous tabs on startup"
 msgstr "_Przywróć poprzednie zakładki przy starcie"
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Pokaż _pasek larty:"
+msgid "Show tab _bar"
+msgstr "Pokaż _pasek larty"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1068,12 +1068,12 @@ msgid "Never"
 msgstr "Nigdy"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Pozycja paska karty:"
+msgid "Tab bar position"
+msgstr "Pozycja paska karty"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Etykiety zakładek elips:"
+msgid "Ellipsize tab labels"
+msgstr "Etykiety zakładek elips"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1088,8 +1088,8 @@ msgid "End"
 msgstr "Koniec"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Szerokość karty:"
+msgid "Tab width"
+msgstr "Szerokość karty"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1051,8 +1051,8 @@ msgid "_Restore previous tabs on startup"
 msgstr ""
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Mostrar Barra de Abas:"
+msgid "Show tab _bar"
+msgstr "Mostrar Barra de Abas"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1063,12 +1063,12 @@ msgid "Never"
 msgstr "Nunca"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Posição da Barra de Abas:"
+msgid "Tab bar position"
+msgstr "Posição da Barra de Abas"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Arredondar rótulos das abas:"
+msgid "Ellipsize tab labels"
+msgstr "Arredondar rótulos das abas"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1083,8 +1083,8 @@ msgid "End"
 msgstr "Fim"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Largura da aba:"
+msgid "Tab width"
+msgstr "Largura da aba"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1052,8 +1052,8 @@ msgid "_Restore previous tabs on startup"
 msgstr "_Восстановить предыдущие вкладки при запуске"
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Показывать панель вкладок:"
+msgid "Show tab _bar"
+msgstr "Показывать панель вкладок"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1064,12 +1064,12 @@ msgid "Never"
 msgstr "Никогда"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Положение панели вкладок:"
+msgid "Tab bar position"
+msgstr "Положение панели вкладок"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Сокращение названия вкладок:"
+msgid "Ellipsize tab labels"
+msgstr "Сокращение названия вкладок"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1084,8 +1084,8 @@ msgid "End"
 msgstr "В конце"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Ширина вкладки:"
+msgid "Tab width"
+msgstr "Ширина вкладки"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1049,8 +1049,8 @@ msgid "_Restore previous tabs on startup"
 msgstr "_Başlangıçta önceki sekmeleri geri yükle"
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "Sekme _çubuğunu göster:"
+msgid "Show tab _bar"
+msgstr "Sekme _çubuğunu göster"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1061,12 +1061,12 @@ msgid "Never"
 msgstr "Hiçbir zaman"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "Sekme çubuğu konumu:"
+msgid "Tab bar position"
+msgstr "Sekme çubuğu konumu"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "Uzun sekme adlarını kısalt:"
+msgid "Ellipsize tab labels"
+msgstr "Uzun sekme adlarını kısalt"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1081,8 +1081,8 @@ msgid "End"
 msgstr "Son"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "Sekme genişliği:"
+msgid "Tab width"
+msgstr "Sekme genişliği"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1042,8 +1042,8 @@ msgid "_Restore previous tabs on startup"
 msgstr "_启动时还原以前的选项卡"
 
 #: ddterm/pref/tabs.js:30
-msgid "Show tab _bar:"
-msgstr "显示标签 _栏："
+msgid "Show tab _bar"
+msgstr "显示标签 _栏"
 
 #: ddterm/pref/tabs.js:32 ddterm/pref/text.js:100
 msgid "Always"
@@ -1054,12 +1054,12 @@ msgid "Never"
 msgstr "从不"
 
 #: ddterm/pref/tabs.js:40
-msgid "Tab bar position:"
-msgstr "标签栏的位置："
+msgid "Tab bar position"
+msgstr "标签栏的位置"
 
 #: ddterm/pref/tabs.js:51
-msgid "Ellipsize tab labels:"
-msgstr "缩写标签页文本:"
+msgid "Ellipsize tab labels"
+msgstr "缩写标签页文本"
 
 #: ddterm/pref/tabs.js:54
 msgid "Start"
@@ -1074,8 +1074,8 @@ msgid "End"
 msgstr "结尾"
 
 #: ddterm/pref/tabs.js:79
-msgid "Tab width:"
-msgstr "标签页宽度："
+msgid "Tab width"
+msgstr "标签页宽度"
 
 #: ddterm/pref/tabs.js:96
 msgid "Expand tabs"


### PR DESCRIPTION
`PreferencesRow` `title` should not end with `:`.

https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1578