### PR TITLE
prefs/text: remove trailing colons

### DIFF
--- a/ddterm/pref/text.js
+++ b/ddterm/pref/text.js
@@ -76,7 +76,7 @@ export class TextGroup extends PreferencesGroup {
         });
 
         this.#font_row = new FontRow({
-            title: this.gettext('Custom _font:'),
+            title: this.gettext('Custom _font'),
             visible: true,
             use_underline: true,
         });
@@ -92,7 +92,7 @@ export class TextGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'text-blink-mode',
-            title: this.gettext('Allow _blinking text:'),
+            title: this.gettext('Allow _blinking text'),
             model: {
                 never: this.gettext('Never'),
                 focused: this.gettext('When focused'),
@@ -103,7 +103,7 @@ export class TextGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'cursor-shape',
-            title: this.gettext('Cursor _shape:'),
+            title: this.gettext('Cursor _shape'),
             model: {
                 block: this.gettext('Block'),
                 ibeam: this.gettext('I-Beam'),
@@ -113,7 +113,7 @@ export class TextGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'cursor-blink-mode',
-            title: this.gettext('_Cursor blinking:'),
+            title: this.gettext('_Cursor blinking'),
             model: {
                 system: this.gettext('Default'),
                 on: this.gettext('Enabled'),

--- a/po/cs.po
+++ b/po/cs.po
@@ -1119,12 +1119,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "Vlastní _font:"
+msgid "Custom _font"
+msgstr "Vlastní _font"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Povolit _blikající text:"
+msgid "Allow _blinking text"
+msgstr "Povolit _blikající text"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1135,8 +1135,8 @@ msgid "When unfocused"
 msgstr "Mimo zaměření"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "_Tvar kurzoru:"
+msgid "Cursor _shape"
+msgstr "_Tvar kurzoru"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1151,8 +1151,8 @@ msgid "Underline"
 msgstr "Podtržení"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "Blikání _kurzoru:"
+msgid "_Cursor blinking"
+msgstr "Blikání _kurzoru"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/ddterm@amezin.github.com.pot
+++ b/po/ddterm@amezin.github.com.pot
@@ -1102,11 +1102,11 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
+msgid "Custom _font"
 msgstr ""
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
+msgid "Allow _blinking text"
 msgstr ""
 
 #: ddterm/pref/text.js:98
@@ -1118,7 +1118,7 @@ msgid "When unfocused"
 msgstr ""
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
+msgid "Cursor _shape"
 msgstr ""
 
 #: ddterm/pref/text.js:108
@@ -1134,7 +1134,7 @@ msgid "Underline"
 msgstr ""
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
+msgid "_Cursor blinking"
 msgstr ""
 
 #: ddterm/pref/text.js:119

--- a/po/de.po
+++ b/po/de.po
@@ -1111,12 +1111,12 @@ msgid "Use System Font"
 msgstr "Systemschriftart verwenden"
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "Benutzerdefinierte Schri_ftart:"
+msgid "Custom _font"
+msgstr "Benutzerdefinierte Schri_ftart"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "_Blinkenden Text zulassen:"
+msgid "Allow _blinking text"
+msgstr "_Blinkenden Text zulassen"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1127,8 +1127,8 @@ msgid "When unfocused"
 msgstr "Wenn nicht fokussiert"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "Cursor-_Form:"
+msgid "Cursor _shape"
+msgstr "Cursor-_Form"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1143,8 +1143,8 @@ msgid "Underline"
 msgstr "Unterstrich"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "_Cursor-Blinken:"
+msgid "_Cursor blinking"
+msgstr "_Cursor-Blinken"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/el.po
+++ b/po/el.po
@@ -1131,12 +1131,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
+msgid "Custom _font"
 msgstr "Προσαρμοσμένη _γραμματοσειρά"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Να επιτρέπεται το κείμενο που αναβοσβήνει:"
+msgid "Allow _blinking text"
+msgstr "Να επιτρέπεται το κείμενο που αναβοσβήνει"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1147,8 +1147,8 @@ msgid "When unfocused"
 msgstr "Όταν δεν είναι εστιασμένο"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "Δρομέας _σχήμα:"
+msgid "Cursor _shape"
+msgstr "Δρομέας _σχήμα"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1163,8 +1163,8 @@ msgid "Underline"
 msgstr "Υπογραμμιση"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "_Ο δρομέας αναβοσβήνει:"
+msgid "_Cursor blinking"
+msgstr "_Ο δρομέας αναβοσβήνει"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/eo.po
+++ b/po/eo.po
@@ -1110,11 +1110,11 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
+msgid "Custom _font"
 msgstr ""
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
+msgid "Allow _blinking text"
 msgstr ""
 
 #: ddterm/pref/text.js:98
@@ -1126,7 +1126,7 @@ msgid "When unfocused"
 msgstr ""
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
+msgid "Cursor _shape"
 msgstr ""
 
 #: ddterm/pref/text.js:108
@@ -1142,7 +1142,7 @@ msgid "Underline"
 msgstr "Substreko"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
+msgid "_Cursor blinking"
 msgstr ""
 
 #: ddterm/pref/text.js:119

--- a/po/es.po
+++ b/po/es.po
@@ -1113,12 +1113,12 @@ msgid "Use System Font"
 msgstr "Utilizar tipografía del sistema"
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "_Tipografía personalizada:"
+msgid "Custom _font"
+msgstr "_Tipografía personalizada"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Permitir texto _parpadeante:"
+msgid "Allow _blinking text"
+msgstr "Permitir texto _parpadeante"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1129,8 +1129,8 @@ msgid "When unfocused"
 msgstr "Cuando se desenfoca"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "_Forma del cursor:"
+msgid "Cursor _shape"
+msgstr "_Forma del cursor"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1145,8 +1145,8 @@ msgid "Underline"
 msgstr "Subrayado"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "Parpadeo del _cursor:"
+msgid "_Cursor blinking"
+msgstr "Parpadeo del _cursor"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1125,12 +1125,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "Police personnalisée :"
+msgid "Custom _font"
+msgstr "Police personnalisée"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Autoriser le texte clignotant :"
+msgid "Allow _blinking text"
+msgstr "Autoriser le texte clignotant"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1141,8 +1141,8 @@ msgid "When unfocused"
 msgstr "Hors du focus"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "Forme du curseur :"
+msgid "Cursor _shape"
+msgstr "Forme du curseur"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1157,8 +1157,8 @@ msgid "Underline"
 msgstr "Souligné"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "Clignotement du curseur :"
+msgid "_Cursor blinking"
+msgstr "Clignotement du curseur"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/it.po
+++ b/po/it.po
@@ -1124,12 +1124,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "_font personalizzato:"
+msgid "Custom _font"
+msgstr "_font personalizzato"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Consentire il testo _lampeggiante:"
+msgid "Allow _blinking text"
+msgstr "Consentire il testo _lampeggiante"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1140,8 +1140,8 @@ msgid "When unfocused"
 msgstr "Quando non è focalizzato"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "_forma cursore:"
+msgid "Cursor _shape"
+msgstr "_forma cursore"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1156,8 +1156,8 @@ msgid "Underline"
 msgstr "Sottolinea"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "_cursore lampeggiante:"
+msgid "_Cursor blinking"
+msgstr "_cursore lampeggiante"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -1116,12 +1116,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "Egendefinert _skrift:"
+msgid "Custom _font"
+msgstr "Egendefinert _skrift"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Tillat _blinkende tekst:"
+msgid "Allow _blinking text"
+msgstr "Tillat _blinkende tekst"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1132,8 +1132,8 @@ msgid "When unfocused"
 msgstr "Når utenfor fokus"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "Peker_form:"
+msgid "Cursor _shape"
+msgstr "Peker_form"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1148,8 +1148,8 @@ msgid "Underline"
 msgstr "Understrek"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "_Blinkende peker:"
+msgid "_Cursor blinking"
+msgstr "_Blinkende peker"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1128,12 +1128,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "Niestandardowa _czcionka:"
+msgid "Custom _font"
+msgstr "Niestandardowa _czcionka"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Zezwalaj na _migający tekst:"
+msgid "Allow _blinking text"
+msgstr "Zezwalaj na _migający tekst"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1144,8 +1144,8 @@ msgid "When unfocused"
 msgstr "Kiedy nieaktywne"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "_Kształt kursora:"
+msgid "Cursor _shape"
+msgstr "_Kształt kursora"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1160,8 +1160,8 @@ msgid "Underline"
 msgstr "Podkreślenie"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "Miganie _kursora:"
+msgid "_Cursor blinking"
+msgstr "Miganie _kursora"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1123,12 +1123,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "Fonte personalizada:"
+msgid "Custom _font"
+msgstr "Fonte personalizada"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Permitir texto piscante:"
+msgid "Allow _blinking text"
+msgstr "Permitir texto piscante"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1139,8 +1139,8 @@ msgid "When unfocused"
 msgstr "Quando fora de foco"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "Forma do cursor:"
+msgid "Cursor _shape"
+msgstr "Forma do cursor"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1155,8 +1155,8 @@ msgid "Underline"
 msgstr "Sublinha"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "Cursor piscante:"
+msgid "_Cursor blinking"
+msgstr "Cursor piscante"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1124,12 +1124,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "Пользовательский шрифт:"
+msgid "Custom _font"
+msgstr "Пользовательский шрифт"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "Разрешить моргание текста:"
+msgid "Allow _blinking text"
+msgstr "Разрешить моргание текста"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1140,8 +1140,8 @@ msgid "When unfocused"
 msgstr "Когда не в фокусе"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "Вид курсора:"
+msgid "Cursor _shape"
+msgstr "Вид курсора"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1156,8 +1156,8 @@ msgid "Underline"
 msgstr "Подчёркивание"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "Моргание курсора:"
+msgid "_Cursor blinking"
+msgstr "Моргание курсора"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1121,12 +1121,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "Özel _font:"
+msgid "Custom _font"
+msgstr "Özel _font"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "_Yanıp sönen yazıya izin ver:"
+msgid "Allow _blinking text"
+msgstr "_Yanıp sönen yazıya izin ver"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1137,8 +1137,8 @@ msgid "When unfocused"
 msgstr "Odaklanılmadığında"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "İmleç _şekli:"
+msgid "Cursor _shape"
+msgstr "İmleç _şekli"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1153,8 +1153,8 @@ msgid "Underline"
 msgstr "Altı çizili"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "Yanıp Sönen _İmleç:"
+msgid "_Cursor blinking"
+msgstr "Yanıp Sönen _İmleç"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1114,12 +1114,12 @@ msgid "Use System Font"
 msgstr ""
 
 #: ddterm/pref/text.js:79
-msgid "Custom _font:"
-msgstr "自定义 _字体："
+msgid "Custom _font"
+msgstr "自定义 _字体"
 
 #: ddterm/pref/text.js:95
-msgid "Allow _blinking text:"
-msgstr "允许 _闪烁文本："
+msgid "Allow _blinking text"
+msgstr "允许 _闪烁文本"
 
 #: ddterm/pref/text.js:98
 msgid "When focused"
@@ -1130,8 +1130,8 @@ msgid "When unfocused"
 msgstr "未聚焦时"
 
 #: ddterm/pref/text.js:106
-msgid "Cursor _shape:"
-msgstr "光标 _形状："
+msgid "Cursor _shape"
+msgstr "光标 _形状"
 
 #: ddterm/pref/text.js:108
 msgid "Block"
@@ -1146,8 +1146,8 @@ msgid "Underline"
 msgstr "下划线"
 
 #: ddterm/pref/text.js:116
-msgid "_Cursor blinking:"
-msgstr "_光标闪烁："
+msgid "_Cursor blinking"
+msgstr "_光标闪烁"
 
 #: ddterm/pref/text.js:119
 msgid "Enabled"


### PR DESCRIPTION
`PreferencesRow` `title` should not end with `:`.

https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1578