### PR TITLE
prefs/compatibility: remove trailing colons

### DIFF
--- a/ddterm/pref/compatibility.js
+++ b/ddterm/pref/compatibility.js
@@ -29,19 +29,19 @@ export class CompatibilityGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'backspace-binding',
-            title: this.gettext('_Backspace key generates:'),
+            title: this.gettext('_Backspace key generates'),
             model,
         });
 
         this.add_combo_text_row({
             key: 'delete-binding',
-            title: this.gettext('_Delete key generates:'),
+            title: this.gettext('_Delete key generates'),
             model,
         });
 
         this.add_combo_text_row({
             key: 'cjk-utf8-ambiguous-width',
-            title: this.gettext('Ambiguous-_width characters:'),
+            title: this.gettext('Ambiguous-_width characters'),
             model: {
                 narrow: this.gettext('Narrow'),
                 wide: this.gettext('Wide'),

--- a/po/cs.po
+++ b/po/cs.po
@@ -765,16 +765,16 @@ msgid "TTY Erase"
 msgstr "Vymazání TTY"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "Tlačítko _Backspace generuje:"
+msgid "_Backspace key generates"
+msgstr "Tlačítko _Backspace generuje"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "Tlačítko _Delete generuje:"
+msgid "_Delete key generates"
+msgstr "Tlačítko _Delete generuje"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Nejednoznačná šířka znaků:"
+msgid "Ambiguous-_width characters"
+msgstr "Nejednoznačná šířka znaků"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/ddterm@amezin.github.com.pot
+++ b/po/ddterm@amezin.github.com.pot
@@ -762,15 +762,15 @@ msgid "TTY Erase"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
+msgid "_Backspace key generates"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
+msgid "_Delete key generates"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
+msgid "Ambiguous-_width characters"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:46

--- a/po/de.po
+++ b/po/de.po
@@ -770,16 +770,16 @@ msgid "TTY Erase"
 msgstr "TTY-Löschen"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "Rücktaste erzeugt:"
+msgid "_Backspace key generates"
+msgstr "Rücktaste erzeugt"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "Entfernen-Taste erzeugt:"
+msgid "_Delete key generates"
+msgstr "Entfernen-Taste erzeugt"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Zeichen mit unterschiedlicher Breite:"
+msgid "Ambiguous-_width characters"
+msgstr "Zeichen mit unterschiedlicher Breite"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/el.po
+++ b/po/el.po
@@ -776,15 +776,15 @@ msgid "TTY Erase"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
+msgid "_Backspace key generates"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
+msgid "_Delete key generates"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
+msgid "Ambiguous-_width characters"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:46

--- a/po/eo.po
+++ b/po/eo.po
@@ -766,15 +766,15 @@ msgid "TTY Erase"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
+msgid "_Backspace key generates"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
+msgid "_Delete key generates"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
+msgid "Ambiguous-_width characters"
 msgstr ""
 
 #: ddterm/pref/compatibility.js:46

--- a/po/es.po
+++ b/po/es.po
@@ -773,16 +773,16 @@ msgid "TTY Erase"
 msgstr "Borrado TTY"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "La tecla _Retroceso genera:"
+msgid "_Backspace key generates"
+msgstr "La tecla _Retroceso genera"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "La tecla _Suprimir genera:"
+msgid "_Delete key generates"
+msgstr "La tecla _Suprimir genera"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Caracteres de _anchura ambigua:"
+msgid "Ambiguous-_width characters"
+msgstr "Caracteres de _anchura ambigua"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/fr.po
+++ b/po/fr.po
@@ -775,16 +775,16 @@ msgid "TTY Erase"
 msgstr "Effacement du TTY"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "La touche « Retour arrière» permet :"
+msgid "_Backspace key generates"
+msgstr "La touche « Retour arrière» permet"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "La touche « Suppr » permet :"
+msgid "_Delete key generates"
+msgstr "La touche « Suppr » permet"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Caractères de largeur ambigüe :"
+msgid "Ambiguous-_width characters"
+msgstr "Caractères de largeur ambigüe"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/it.po
+++ b/po/it.po
@@ -774,16 +774,16 @@ msgid "TTY Erase"
 msgstr "Cancellazione TTY"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "Il tasto _Backspace genera:"
+msgid "_Backspace key generates"
+msgstr "Il tasto _Backspace genera"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "Il tasto _Canc genera:"
+msgid "_Delete key generates"
+msgstr "Il tasto _Canc genera"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Caratteri di _larghezza ambigua:"
+msgid "Ambiguous-_width characters"
+msgstr "Caratteri di _larghezza ambigua"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -765,16 +765,16 @@ msgid "TTY Erase"
 msgstr "TTY-sletting"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "_Rettetast genererer:"
+msgid "_Backspace key generates"
+msgstr "_Rettetast genererer"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "_Delete-tast genererer:"
+msgid "_Delete key generates"
+msgstr "_Delete-tast genererer"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Tvetydig-_vide tegn:"
+msgid "Ambiguous-_width characters"
+msgstr "Tvetydig-_vide tegn"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/pl.po
+++ b/po/pl.po
@@ -778,16 +778,16 @@ msgid "TTY Erase"
 msgstr "Wyczyść TTY"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "Klawisz _Backspace generuje:"
+msgid "_Backspace key generates"
+msgstr "Klawisz _Backspace generuje"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "Klawisz _Delete generuje:"
+msgid "_Delete key generates"
+msgstr "Klawisz _Delete generuje"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Znaki o różnej _szerokości:"
+msgid "Ambiguous-_width characters"
+msgstr "Znaki o różnej _szerokości"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/pt.po
+++ b/po/pt.po
@@ -773,16 +773,16 @@ msgid "TTY Erase"
 msgstr "Limpar TTY"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "Tecla Backspace gera:"
+msgid "_Backspace key generates"
+msgstr "Tecla Backspace gera"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "Tecla DELETE gera:"
+msgid "_Delete key generates"
+msgstr "Tecla DELETE gera"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Caracteres de largura ambígua:"
+msgid "Ambiguous-_width characters"
+msgstr "Caracteres de largura ambígua"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/ru.po
+++ b/po/ru.po
@@ -774,16 +774,16 @@ msgid "TTY Erase"
 msgstr "Очистить терминал"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "Клавиша «Backspace» генерирует:"
+msgid "_Backspace key generates"
+msgstr "Клавиша «Backspace» генерирует"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "Клавиша «Delete» генерирует:"
+msgid "_Delete key generates"
+msgstr "Клавиша «Delete» генерирует"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Символы неоднозначной ширины:"
+msgid "Ambiguous-_width characters"
+msgstr "Символы неоднозначной ширины"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/tr.po
+++ b/po/tr.po
@@ -771,16 +771,16 @@ msgid "TTY Erase"
 msgstr "TTY Sil"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "_Backspace tuşu üretir:"
+msgid "_Backspace key generates"
+msgstr "_Backspace tuşu üretir"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "_Delete tuşu üretir:"
+msgid "_Delete key generates"
+msgstr "_Delete tuşu üretir"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "Belirsiz-_genişlikte karakterler:"
+msgid "Ambiguous-_width characters"
+msgstr "Belirsiz-_genişlikte karakterler"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -764,16 +764,16 @@ msgid "TTY Erase"
 msgstr "TTY 擦除"
 
 #: ddterm/pref/compatibility.js:32
-msgid "_Backspace key generates:"
-msgstr "_Backspace 键生成："
+msgid "_Backspace key generates"
+msgstr "_Backspace 键生成"
 
 #: ddterm/pref/compatibility.js:38
-msgid "_Delete key generates:"
-msgstr "_Delete 键生成："
+msgid "_Delete key generates"
+msgstr "_Delete 键生成"
 
 #: ddterm/pref/compatibility.js:44
-msgid "Ambiguous-_width characters:"
-msgstr "有歧义 _宽度的字符："
+msgid "Ambiguous-_width characters"
+msgstr "有歧义 _宽度的字符"
 
 #: ddterm/pref/compatibility.js:46
 msgid "Narrow"


### PR DESCRIPTION
`PreferencesRow` `title` should not end with `:`.

https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1578