### PR TITLE
prefs/colors: remove trailing colons

### DIFF
--- a/ddterm/pref/colors.js
+++ b/ddterm/pref/colors.js
@@ -358,7 +358,7 @@ export class ColorsGroup extends PreferencesGroup {
 
         this.add_combo_text_row({
             key: 'theme-variant',
-            title: this.gettext('Theme _variant:'),
+            title: this.gettext('Theme _variant'),
             model: {
                 system: this.gettext('Default'),
                 light: this.gettext('Light'),
@@ -406,7 +406,7 @@ export class ColorsGroup extends PreferencesGroup {
 
         this.#color_scheme_combo = new ComboRow({
             visible: true,
-            title: this.gettext('Color _scheme:'),
+            title: this.gettext('Color _scheme'),
             use_underline: true,
         });
 
@@ -440,7 +440,7 @@ export class ColorsGroup extends PreferencesGroup {
 
         this.#bold_color_expander = this.add_expander_row({
             key: 'bold-color-same-as-fg',
-            title: this.gettext('Bold color:'),
+            title: this.gettext('Bold color'),
             flags: Gio.SettingsBindFlags.NO_SENSITIVITY | Gio.SettingsBindFlags.INVERT_BOOLEAN,
         });
 
@@ -457,7 +457,7 @@ export class ColorsGroup extends PreferencesGroup {
 
         this.#cursor_color_expander = this.add_expander_row({
             key: 'cursor-colors-set',
-            title: this.gettext('Cursor color:'),
+            title: this.gettext('Cursor color'),
             flags: Gio.SettingsBindFlags.NO_SENSITIVITY,
         });
 
@@ -507,7 +507,7 @@ export class ColorsGroup extends PreferencesGroup {
 
         this.#highlight_color_expander = this.add_expander_row({
             key: 'highlight-colors-set',
-            title: this.gettext('Highlight color:'),
+            title: this.gettext('Highlight color'),
             flags: Gio.SettingsBindFlags.NO_SENSITIVITY,
         });
 
@@ -574,7 +574,7 @@ export class ColorsGroup extends PreferencesGroup {
             round_digits: 2,
             visible: true,
             use_underline: true,
-            title: this.gettext('_Background opacity:'),
+            title: this.gettext('_Background opacity'),
         });
 
         const percent_format = new Intl.NumberFormat(undefined, { style: 'percent' });
@@ -714,7 +714,7 @@ export class ColorsGroup extends PreferencesGroup {
 
         const palette_combo = new ComboRow({
             visible: true,
-            title: this.gettext('_Palette:'),
+            title: this.gettext('_Palette'),
             use_underline: true,
         });
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -573,8 +573,8 @@ msgid "Colors"
 msgstr "Barvy"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "_Varianta vzhledu:"
+msgid "Theme _variant"
+msgstr "_Varianta vzhledu"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -641,8 +641,8 @@ msgid "Custom"
 msgstr "Vlastní"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Barevné _schéma:"
+msgid "Color _scheme"
+msgstr "Barevné _schéma"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -653,16 +653,16 @@ msgid "Background Color"
 msgstr "Barva pozadí"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Barva tučného písma:"
+msgid "Bold color"
+msgstr "Barva tučného písma"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Barva tučného písma"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Barva kurzoru:"
+msgid "Cursor color"
+msgstr "Barva kurzoru"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -673,8 +673,8 @@ msgid "Cursor Background Color"
 msgstr "Barva pozadí kurzoru"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Barva zvýraznění:"
+msgid "Highlight color"
+msgstr "Barva zvýraznění"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -685,8 +685,8 @@ msgid "Highlight Background Color"
 msgstr "Zvýrazněná barva pozadí"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "Průhlednost _Pozadí:"
+msgid "_Background opacity"
+msgstr "Průhlednost _Pozadí"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -713,8 +713,8 @@ msgid "Solarized"
 msgstr "Solarizované"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "Barevná _paleta:"
+msgid "_Palette"
+msgstr "Barevná _paleta"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/ddterm@amezin.github.com.pot
+++ b/po/ddterm@amezin.github.com.pot
@@ -570,7 +570,7 @@ msgid "Colors"
 msgstr ""
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
+msgid "Theme _variant"
 msgstr ""
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
@@ -638,7 +638,7 @@ msgid "Custom"
 msgstr ""
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
+msgid "Color _scheme"
 msgstr ""
 
 #: ddterm/pref/colors.js:428
@@ -650,7 +650,7 @@ msgid "Background Color"
 msgstr ""
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
+msgid "Bold color"
 msgstr ""
 
 #: ddterm/pref/colors.js:451
@@ -658,7 +658,7 @@ msgid "Bold Color"
 msgstr ""
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
+msgid "Cursor color"
 msgstr ""
 
 #: ddterm/pref/colors.js:482
@@ -670,7 +670,7 @@ msgid "Cursor Background Color"
 msgstr ""
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
+msgid "Highlight color"
 msgstr ""
 
 #: ddterm/pref/colors.js:532
@@ -682,7 +682,7 @@ msgid "Highlight Background Color"
 msgstr ""
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
+msgid "_Background opacity"
 msgstr ""
 
 #: ddterm/pref/colors.js:598
@@ -710,7 +710,7 @@ msgid "Solarized"
 msgstr ""
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
+msgid "_Palette"
 msgstr ""
 
 #: ddterm/pref/colors.js:790

--- a/po/de.po
+++ b/po/de.po
@@ -578,8 +578,8 @@ msgid "Colors"
 msgstr "Farben"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "Thema-_Variante:"
+msgid "Theme _variant"
+msgstr "Thema-_Variante"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -646,8 +646,8 @@ msgid "Custom"
 msgstr "Benutzerdefiniert"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Farb_schema:"
+msgid "Color _scheme"
+msgstr "Farb_schema"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -658,16 +658,16 @@ msgid "Background Color"
 msgstr "Hintergrundfarbe"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Fett Farbe:"
+msgid "Bold color"
+msgstr "Fett Farbe"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Fett Farbe"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Cursorfarbe:"
+msgid "Cursor color"
+msgstr "Cursorfarbe"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -678,8 +678,8 @@ msgid "Cursor Background Color"
 msgstr "Cursor Hintergrundfarbe"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Hervorhebungsfarbe:"
+msgid "Highlight color"
+msgstr "Hervorhebungsfarbe"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -690,8 +690,8 @@ msgid "Highlight Background Color"
 msgstr "Hervorhebung Hintergrundfarbe"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "Hintergrund-Deckkraft:"
+msgid "_Background opacity"
+msgstr "Hintergrund-Deckkraft"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -718,8 +718,8 @@ msgid "Solarized"
 msgstr "Solarisiert"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_Palette:"
+msgid "_Palette"
+msgstr "_Palette"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/el.po
+++ b/po/el.po
@@ -584,7 +584,7 @@ msgid "Colors"
 msgstr "Χρώμματα"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
+msgid "Theme _variant"
 msgstr ""
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
@@ -652,7 +652,7 @@ msgid "Custom"
 msgstr "Παραμετροποιημένο"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
+msgid "Color _scheme"
 msgstr ""
 
 #: ddterm/pref/colors.js:428
@@ -664,7 +664,7 @@ msgid "Background Color"
 msgstr ""
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
+msgid "Bold color"
 msgstr ""
 
 #: ddterm/pref/colors.js:451
@@ -672,7 +672,7 @@ msgid "Bold Color"
 msgstr ""
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
+msgid "Cursor color"
 msgstr ""
 
 #: ddterm/pref/colors.js:482
@@ -684,7 +684,7 @@ msgid "Cursor Background Color"
 msgstr ""
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
+msgid "Highlight color"
 msgstr ""
 
 #: ddterm/pref/colors.js:532
@@ -696,8 +696,8 @@ msgid "Highlight Background Color"
 msgstr "Επισημάνετε το χρώμα φόντου"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "_Αδιαφάνεια φόντου:"
+msgid "_Background opacity"
+msgstr "_Αδιαφάνεια φόντου"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -724,8 +724,8 @@ msgid "Solarized"
 msgstr ""
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "Παλέτα :"
+msgid "_Palette"
+msgstr "Παλέτα"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/eo.po
+++ b/po/eo.po
@@ -574,8 +574,8 @@ msgid "Colors"
 msgstr "Koloroj"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "Etosa _vario:"
+msgid "Theme _variant"
+msgstr "Etosa _vario"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -642,8 +642,8 @@ msgid "Custom"
 msgstr ""
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Kolor_skemo:"
+msgid "Color _scheme"
+msgstr "Kolor_skemo"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -654,16 +654,16 @@ msgid "Background Color"
 msgstr "Fona koloro"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Grasa koloro:"
+msgid "Bold color"
+msgstr "Grasa koloro"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Grasa koloro"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Kursora koloro:"
+msgid "Cursor color"
+msgstr "Kursora koloro"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -674,8 +674,8 @@ msgid "Cursor Background Color"
 msgstr "Kursora fona koloro"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Reliefiga koloro:"
+msgid "Highlight color"
+msgstr "Reliefiga koloro"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -686,8 +686,8 @@ msgid "Highlight Background Color"
 msgstr "Reliefiga fona koloro"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "_Fona opako:"
+msgid "_Background opacity"
+msgstr "_Fona opako"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -714,8 +714,8 @@ msgid "Solarized"
 msgstr ""
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_Paletro:"
+msgid "_Palette"
+msgstr "_Paletro"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/es.po
+++ b/po/es.po
@@ -581,8 +581,8 @@ msgid "Colors"
 msgstr "Colores"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "_Variante del tema:"
+msgid "Theme _variant"
+msgstr "_Variante del tema"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -649,8 +649,8 @@ msgid "Custom"
 msgstr "Personalizado"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "_Esquema de colores:"
+msgid "Color _scheme"
+msgstr "_Esquema de colores"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -661,16 +661,16 @@ msgid "Background Color"
 msgstr "Color del fondo"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Color de negrita:"
+msgid "Bold color"
+msgstr "Color de negrita"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Color de negrita"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Color del cursor:"
+msgid "Cursor color"
+msgstr "Color del cursor"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -681,8 +681,8 @@ msgid "Cursor Background Color"
 msgstr "Color del fondo del cursor"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Color de resaltado:"
+msgid "Highlight color"
+msgstr "Color de resaltado"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -693,8 +693,8 @@ msgid "Highlight Background Color"
 msgstr "Color de Fondo de Resaltado"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "Opacidad del _fondo:"
+msgid "_Background opacity"
+msgstr "Opacidad del _fondo"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -721,8 +721,8 @@ msgid "Solarized"
 msgstr "Solar"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_Paleta:"
+msgid "_Palette"
+msgstr "_Paleta"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/fr.po
+++ b/po/fr.po
@@ -583,8 +583,8 @@ msgid "Colors"
 msgstr "Couleurs"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "Thème alternatif :"
+msgid "Theme _variant"
+msgstr "Thème alternatif"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -651,8 +651,8 @@ msgid "Custom"
 msgstr "Personalisé"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Palettes prédéfinies :"
+msgid "Color _scheme"
+msgstr "Palettes prédéfinies"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -663,16 +663,16 @@ msgid "Background Color"
 msgstr "Couleur d'arrière-plan"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Couleur du gras :"
+msgid "Bold color"
+msgstr "Couleur du gras"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Couleur du gras"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Couleur du curseur :"
+msgid "Cursor color"
+msgstr "Couleur du curseur"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -683,8 +683,8 @@ msgid "Cursor Background Color"
 msgstr "Couleur d'arrière-plan du curseur"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Couleur de mise en évidence :"
+msgid "Highlight color"
+msgstr "Couleur de mise en évidence"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -695,8 +695,8 @@ msgid "Highlight Background Color"
 msgstr "Couleur d'arrière-plan de la mise en évidence"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "Opacité de l'arrière-plan :"
+msgid "_Background opacity"
+msgstr "Opacité de l'arrière-plan"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -723,8 +723,8 @@ msgid "Solarized"
 msgstr "Solarisé"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "Palette :"
+msgid "_Palette"
+msgstr "Palette"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/it.po
+++ b/po/it.po
@@ -582,8 +582,8 @@ msgid "Colors"
 msgstr "Colori"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "Tema _variante:"
+msgid "Theme _variant"
+msgstr "Tema _variante"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -650,8 +650,8 @@ msgid "Custom"
 msgstr "Personalizzato"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Colore _schema:"
+msgid "Color _scheme"
+msgstr "Colore _schema"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -662,16 +662,16 @@ msgid "Background Color"
 msgstr "Colore di sfondo"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Colore grassetto:"
+msgid "Bold color"
+msgstr "Colore grassetto"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Colore grassetto"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Colore del cursore:"
+msgid "Cursor color"
+msgstr "Colore del cursore"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -682,8 +682,8 @@ msgid "Cursor Background Color"
 msgstr "Colore di secondo piano del cursore"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Colore di evidenziazione:"
+msgid "Highlight color"
+msgstr "Colore di evidenziazione"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -694,8 +694,8 @@ msgid "Highlight Background Color"
 msgstr "Evidenziazione del colore di sfondo"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "_Opacità dello sfondo:"
+msgid "_Background opacity"
+msgstr "_Opacità dello sfondo"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -722,8 +722,8 @@ msgid "Solarized"
 msgstr "Solarizzato"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_Palette:"
+msgid "_Palette"
+msgstr "_Palette"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -573,8 +573,8 @@ msgid "Colors"
 msgstr "Farger"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "Drakt_variant:"
+msgid "Theme _variant"
+msgstr "Drakt_variant"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -641,8 +641,8 @@ msgid "Custom"
 msgstr "Egendefinert"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Farge_drakt:"
+msgid "Color _scheme"
+msgstr "Farge_drakt"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -653,16 +653,16 @@ msgid "Background Color"
 msgstr "Bakgrunnsfarge"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Fet farge:"
+msgid "Bold color"
+msgstr "Fet farge"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Fet farge"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Pekerfarge:"
+msgid "Cursor color"
+msgstr "Pekerfarge"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -673,8 +673,8 @@ msgid "Cursor Background Color"
 msgstr "Pekerbakgrunnsfarge"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Framhevingsfarge:"
+msgid "Highlight color"
+msgstr "Framhevingsfarge"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -685,8 +685,8 @@ msgid "Highlight Background Color"
 msgstr "Framhevingsbakgrunnsfarge"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "_Bakgrunnsdekkevne:"
+msgid "_Background opacity"
+msgstr "_Bakgrunnsdekkevne"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -713,8 +713,8 @@ msgid "Solarized"
 msgstr "Solarisert"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_Fargepalett:"
+msgid "_Palette"
+msgstr "_Fargepalett"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/pl.po
+++ b/po/pl.po
@@ -586,8 +586,8 @@ msgid "Colors"
 msgstr "Kolory"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "_Wariant motywu:"
+msgid "Theme _variant"
+msgstr "_Wariant motywu"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -654,8 +654,8 @@ msgid "Custom"
 msgstr "Niestandardowe"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "_Schemat kolorów:"
+msgid "Color _scheme"
+msgstr "_Schemat kolorów"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -666,16 +666,16 @@ msgid "Background Color"
 msgstr "Kolor tła"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Kolor pogrubienia:"
+msgid "Bold color"
+msgstr "Kolor pogrubienia"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Kolor pogrubienia"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Kolor kursora:"
+msgid "Cursor color"
+msgstr "Kolor kursora"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -686,8 +686,8 @@ msgid "Cursor Background Color"
 msgstr "Kolor tła wskaźnika"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Kolor wyróżnienia:"
+msgid "Highlight color"
+msgstr "Kolor wyróżnienia"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -698,8 +698,8 @@ msgid "Highlight Background Color"
 msgstr "Podkreślenie tła wskaźnika"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "_Przezroczystość tła:"
+msgid "_Background opacity"
+msgstr "_Przezroczystość tła"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -726,8 +726,8 @@ msgid "Solarized"
 msgstr "Solarized"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_Paleta:"
+msgid "_Palette"
+msgstr "_Paleta"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/pt.po
+++ b/po/pt.po
@@ -581,8 +581,8 @@ msgid "Colors"
 msgstr "Cores"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "Variante de tema:"
+msgid "Theme _variant"
+msgstr "Variante de tema"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -649,8 +649,8 @@ msgid "Custom"
 msgstr "Personalizado"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Cor _scheme:"
+msgid "Color _scheme"
+msgstr "Cor _scheme"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -661,16 +661,16 @@ msgid "Background Color"
 msgstr "Cor do plano de fundo"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Cor negrito:"
+msgid "Bold color"
+msgstr "Cor negrito"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Cor Negrito"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Cor do cursor:"
+msgid "Cursor color"
+msgstr "Cor do cursor"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -681,8 +681,8 @@ msgid "Cursor Background Color"
 msgstr "Cor do plano de fundo do cursor"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Cor destaque:"
+msgid "Highlight color"
+msgstr "Cor destaque"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -693,8 +693,8 @@ msgid "Highlight Background Color"
 msgstr "Cor do plano de fundo do Destaque"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "_Opacidade do plano de fundo:"
+msgid "_Background opacity"
+msgstr "_Opacidade do plano de fundo"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -721,8 +721,8 @@ msgid "Solarized"
 msgstr "Solarized"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_Paleta de cores:"
+msgid "_Palette"
+msgstr "_Paleta de cores"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/ru.po
+++ b/po/ru.po
@@ -582,8 +582,8 @@ msgid "Colors"
 msgstr "Цвета"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "Вариант темы:"
+msgid "Theme _variant"
+msgstr "Вариант темы"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -650,8 +650,8 @@ msgid "Custom"
 msgstr "Пользовательская"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Цветовая схема:"
+msgid "Color _scheme"
+msgstr "Цветовая схема"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -662,16 +662,16 @@ msgid "Background Color"
 msgstr "Цвет фона"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Жирный цвет:"
+msgid "Bold color"
+msgstr "Жирный цвет"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Жирный цвет"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "Цвет курсора:"
+msgid "Cursor color"
+msgstr "Цвет курсора"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -682,8 +682,8 @@ msgid "Cursor Background Color"
 msgstr "Цвет фона курсора"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Цвет подсветки:"
+msgid "Highlight color"
+msgstr "Цвет подсветки"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -694,8 +694,8 @@ msgid "Highlight Background Color"
 msgstr "Цвет подсветки фона"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "Непрозрачность фона:"
+msgid "_Background opacity"
+msgstr "Непрозрачность фона"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -722,8 +722,8 @@ msgid "Solarized"
 msgstr "Solarized"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "Палитра:"
+msgid "_Palette"
+msgstr "Палитра"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/tr.po
+++ b/po/tr.po
@@ -579,8 +579,8 @@ msgid "Colors"
 msgstr "Renkler"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "Tema _çeşidi:"
+msgid "Theme _variant"
+msgstr "Tema _çeşidi"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -647,8 +647,8 @@ msgid "Custom"
 msgstr "Özel"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "Renk _şeması:"
+msgid "Color _scheme"
+msgstr "Renk _şeması"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -659,16 +659,16 @@ msgid "Background Color"
 msgstr "Arkaplan Rengi"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "Kalın rengi:"
+msgid "Bold color"
+msgstr "Kalın rengi"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "Kalın Rengi"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "İmleç rengi:"
+msgid "Cursor color"
+msgstr "İmleç rengi"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -679,8 +679,8 @@ msgid "Cursor Background Color"
 msgstr "İmleç Arka Plan Rengi"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "Vurgulama rengi:"
+msgid "Highlight color"
+msgstr "Vurgulama rengi"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -691,8 +691,8 @@ msgid "Highlight Background Color"
 msgstr "Vurgulama Arka Plan Rengi"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "_Arkaplan opaklığı:"
+msgid "_Background opacity"
+msgstr "_Arkaplan opaklığı"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -719,8 +719,8 @@ msgid "Solarized"
 msgstr "Solarized"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_Renk paleti:"
+msgid "_Palette"
+msgstr "_Renk paleti"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -572,8 +572,8 @@ msgid "Colors"
 msgstr "颜色"
 
 #: ddterm/pref/colors.js:361
-msgid "Theme _variant:"
-msgstr "主题 _变体："
+msgid "Theme _variant"
+msgstr "主题 _变体"
 
 #: ddterm/pref/colors.js:363 ddterm/pref/text.js:118
 msgid "Default"
@@ -640,8 +640,8 @@ msgid "Custom"
 msgstr "自定义"
 
 #: ddterm/pref/colors.js:409
-msgid "Color _scheme:"
-msgstr "配色_方案："
+msgid "Color _scheme"
+msgstr "配色_方案"
 
 #: ddterm/pref/colors.js:428
 msgid "Foreground Color"
@@ -652,16 +652,16 @@ msgid "Background Color"
 msgstr "背景色"
 
 #: ddterm/pref/colors.js:443
-msgid "Bold color:"
-msgstr "粗体颜色："
+msgid "Bold color"
+msgstr "粗体颜色"
 
 #: ddterm/pref/colors.js:451
 msgid "Bold Color"
 msgstr "粗体颜色"
 
 #: ddterm/pref/colors.js:460
-msgid "Cursor color:"
-msgstr "光标颜色："
+msgid "Cursor color"
+msgstr "光标颜色"
 
 #: ddterm/pref/colors.js:482
 msgid "Cursor Foreground Color"
@@ -672,8 +672,8 @@ msgid "Cursor Background Color"
 msgstr "光标背景色"
 
 #: ddterm/pref/colors.js:510
-msgid "Highlight color:"
-msgstr "高亮颜色："
+msgid "Highlight color"
+msgstr "高亮颜色"
 
 #: ddterm/pref/colors.js:532
 msgid "Highlight Foreground Color"
@@ -684,8 +684,8 @@ msgid "Highlight Background Color"
 msgstr "强调背景色"
 
 #: ddterm/pref/colors.js:577
-msgid "_Background opacity:"
-msgstr "_背景不透明度："
+msgid "_Background opacity"
+msgstr "_背景不透明度"
 
 #: ddterm/pref/colors.js:598
 msgid "GNOME"
@@ -712,8 +712,8 @@ msgid "Solarized"
 msgstr "Solarized"
 
 #: ddterm/pref/colors.js:717
-msgid "_Palette:"
-msgstr "_调色板："
+msgid "_Palette"
+msgstr "_调色板"
 
 #: ddterm/pref/colors.js:790
 msgid "Show bold text in _bright colors"


### PR DESCRIPTION
`PreferencesRow` `title` should not end with `:`.

https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1578