### PR TITLE
app/tablabel: fix PreferencesRow title

### DIFF
--- a/ddterm/app/tablabel.js
+++ b/ddterm/app/tablabel.js
@@ -87,7 +87,7 @@ export class TabTitleDialog extends Gtk.Dialog {
         const entry = new EntryRow({
             visible: true,
             use_underline: true,
-            title: Gettext.gettext('Tab _title'),
+            title: Gettext.gettext('Tab _Title'),
         });
 
         this.bind_property(

--- a/po/cs.po
+++ b/po/cs.po
@@ -163,7 +163,7 @@ msgid "Set Custom Tab Title"
 msgstr "Nastavit vlastní název panelu"
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "_Název panelu"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/ddterm@amezin.github.com.pot
+++ b/po/ddterm@amezin.github.com.pot
@@ -162,7 +162,7 @@ msgid "Set Custom Tab Title"
 msgstr ""
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr ""
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/de.po
+++ b/po/de.po
@@ -168,7 +168,7 @@ msgid "Set Custom Tab Title"
 msgstr "Benutzerdefinierten Reitertitel festlegen"
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "_Tab-Name"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/el.po
+++ b/po/el.po
@@ -171,7 +171,7 @@ msgid "Set Custom Tab Title"
 msgstr "Παραμετροποίση τίτλου καρτέλας"
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Titre d'onglet"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/eo.po
+++ b/po/eo.po
@@ -164,7 +164,7 @@ msgstr ""
 #: ddterm/app/tablabel.js:90
 #, fuzzy
 #| msgid "Set tab title"
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Agordi langetan titolon"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/es.po
+++ b/po/es.po
@@ -171,7 +171,7 @@ msgstr "Establecer título de la pestaña personalizado"
 #: ddterm/app/tablabel.js:90
 #, fuzzy
 #| msgid "Set tab title"
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Renombrar el título de la pestaña"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/fr.po
+++ b/po/fr.po
@@ -171,7 +171,7 @@ msgid "Set Custom Tab Title"
 msgstr "Définir un titre d'onglet personnalisé"
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Titre d'onglet"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/it.po
+++ b/po/it.po
@@ -170,7 +170,7 @@ msgstr "Imposta titolo scheda personalizzato"
 #: ddterm/app/tablabel.js:90
 #, fuzzy
 #| msgid "Set tab title"
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Impostare il titolo della scheda"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/ko.po
+++ b/po/ko.po
@@ -165,7 +165,7 @@ msgid "Set Custom Tab Title"
 msgstr "사용자 지정 탭 제목 설정"
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "탭 _제목"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -163,7 +163,7 @@ msgid "Set Custom Tab Title"
 msgstr "Sett egendefinert fanenavn"
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Fanenavn"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/pl.po
+++ b/po/pl.po
@@ -174,7 +174,7 @@ msgstr "Ustaw własny tytuł karty"
 #: ddterm/app/tablabel.js:90
 #, fuzzy
 #| msgid "Set tab title"
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Ustaw inny tytuł karty"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/pt.po
+++ b/po/pt.po
@@ -169,7 +169,7 @@ msgstr "Definir Título da Aba"
 #: ddterm/app/tablabel.js:90
 #, fuzzy
 #| msgid "Set tab title"
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Definir Título da Aba"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/ru.po
+++ b/po/ru.po
@@ -172,7 +172,7 @@ msgid "Set Custom Tab Title"
 msgstr "Изменить название вкладки"
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Название вкладки"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/tr.po
+++ b/po/tr.po
@@ -169,7 +169,7 @@ msgstr "Özel Sekme Başlığı Koy"
 #: ddterm/app/tablabel.js:90
 #, fuzzy
 #| msgid "Set tab title"
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "Sekme başlığını ayarla"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -162,7 +162,7 @@ msgid "Set Custom Tab Title"
 msgstr "设置自定义标签页标题"
 
 #: ddterm/app/tablabel.js:90
-msgid "Tab _title"
+msgid "Tab _Title"
 msgstr "标签页标题"
 
 #: ddterm/app/tablabel.js:104 ddterm/app/ui/menus.ui:215


### PR DESCRIPTION
`PreferencesRow` `title` should use title case, and should not end with `:`.

Remove trailing colon from translations.

Fix capitalization for source strings only: this change can be non-trivial and dependent on the language, so it's left to translators.

https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1578