### PR TITLE
meson: set `native` flag for `find_program()`

### DIFF
--- a/ddterm/pref/ui/gtk4/meson.build
+++ b/ddterm/pref/ui/gtk4/meson.build
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+xsltproc = find_program('xsltproc', native: true)
+
 foreach pref_ui_src_file : pref_ui_src_files
   pref_ui_out_files += custom_target(
     command: [xsltproc, '-o', '@OUTPUT@', files('3to4.xsl'), '@INPUT@'],

--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,6 @@ summary(
   section: 'System-wide installation',
 )
 
-glib_compile_schemas_tool = find_program('glib-compile-schemas')
 xsltproc = find_program('xsltproc')
 
 desktop_file_validate_tool = find_program(

--- a/meson.build
+++ b/meson.build
@@ -69,9 +69,6 @@ summary(
 glib_compile_schemas_tool = find_program('glib-compile-schemas')
 xsltproc = find_program('xsltproc')
 
-xgettext = find_program('xgettext', required: false, disabler: true)
-msgmerge = find_program('msgmerge', required: false, disabler: true)
-
 desktop_file_validate_tool = find_program(
   'desktop-file-validate',
   required: false,

--- a/meson.build
+++ b/meson.build
@@ -66,8 +66,6 @@ summary(
   section: 'System-wide installation',
 )
 
-xsltproc = find_program('xsltproc')
-
 desktop_file_validate_tool = find_program(
   'desktop-file-validate',
   required: false,

--- a/po/meson.build
+++ b/po/meson.build
@@ -22,6 +22,20 @@ gettext_args = [
   '--no-wrap',
 ]
 
+xgettext = find_program(
+  'xgettext',
+  required: false,
+  disabler: true,
+  native: true,
+)
+
+msgmerge = find_program(
+  'msgmerge',
+  required: false,
+  disabler: true,
+  native: true,
+)
+
 gettext_targets = i18n.gettext(
   gettext_domain,
   args: gettext_args,

--- a/schemas/meson.build
+++ b/schemas/meson.build
@@ -4,6 +4,8 @@
 
 schema = files(f'@settings_schema@.gschema.xml')
 
+glib_compile_schemas_tool = find_program('glib-compile-schemas', native: true)
+
 schemas_compiled = custom_target(
   command: [
     glib_compile_schemas_tool,


### PR DESCRIPTION
When searching for the same programs in built-in modules (`i18n`, `gnome`), Meson performs the search in `native=true` mode.