### PR TITLE
fix(i18n): swap French translations for show/hide animation duration

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -543,7 +543,7 @@ msgstr "Animation d'apparition"
 
 #: ddterm/pref/animation.js:114
 msgid "_Show Animation Duration"
-msgstr "Durée de l'animation de disparition"
+msgstr "Durée de l'animation d'apparition"
 
 #: ddterm/pref/animation.js:135
 msgid "_Hide Animation"
@@ -551,7 +551,7 @@ msgstr "Animation de disparition"
 
 #: ddterm/pref/animation.js:146
 msgid "_Hide Animation Duration"
-msgstr "Durée de l'animation d'apparition"
+msgstr "Durée de l'animation de disparition"
 
 #: ddterm/pref/behavior.js:19
 msgid "Behavior"


### PR DESCRIPTION
## Summary

Fix swapped French translations for show/hide animation duration strings.

Closes #1739

## Problem

The French translations for "_Show Animation Duration" and "_Hide Animation Duration" were swapped:

- "_Show Animation Duration" was translated as "Durée de l'animation de disparition" (hide/disappear) — should be apparition (show/appear)
- "_Hide Animation Duration" was translated as "Durée de l'animation d'apparition" (show/appear) — should be disparition (hide/disappear)

## Fix

Swapped the two translations to their correct positions:

```diff
 msgid "_Show Animation Duration"
-msgstr "Durée de l'animation de disparition"
+msgstr "Durée de l'animation d'apparition"

 msgid "_Hide Animation Duration"
-msgstr "Durée de l'animation d'apparition"
+msgstr "Durée de l'animation de disparition"
```