### PR TITLE
Implement copy on selection

### DIFF
--- a/ddterm/app/terminal.js
+++ b/ddterm/app/terminal.js
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Aleksandr Mezin <mezin.alexander@gmail.com>
 // SPDX-FileContributor: Jing Yen Loh
+// SPDX-FileContributor: Mike Lei
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -328,6 +329,13 @@ const TerminalBase = GObject.registerClass({
             GObject.ParamFlags.READABLE,
             true
         ),
+        'copy-on-selection': GObject.ParamSpec.boolean(
+            'copy-on-selection',
+            null,
+            null,
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.EXPLICIT_NOTIFY,
+            false
+        ),
     },
 }, class DDTermTerminal extends Vte.Terminal {
     _init(params) {
@@ -372,6 +380,11 @@ const TerminalBase = GObject.registerClass({
         this.connect('notify::font-scale', () => {
             this.notify('can-increase-font-scale');
             this.notify('can-decrease-font-scale');
+        });
+
+        this.connect('selection-changed', () => {
+            if (this.copy_on_selection && this.get_has_selection())
+                this.copy_clipboard_format(Vte.Format.TEXT);
         });
 
         this._gdk_atom_primary = Gdk.Atom.intern('PRIMARY', true);

--- a/ddterm/app/terminalsettings.js
+++ b/ddterm/app/terminalsettings.js
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Aleksandr Mezin <mezin.alexander@gmail.com>
 // SPDX-FileContributor: Jing Yen Loh
+// SPDX-FileContributor: Mike Lei
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,6 +78,7 @@ const PROPERTIES_CLONE = [
     'color-highlight',
     'color-highlight-foreground',
     'url-detect-patterns',
+    'copy-on-selection',
 ];
 
 const TERMINAL_PSPECS = Object.fromEntries(

--- a/ddterm/pref/text.js
+++ b/ddterm/pref/text.js
@@ -166,6 +166,11 @@ export class TextGroup extends PreferencesGroup {
             title: this.gettext('Detect "news:", "man:" URLs'),
         });
 
+        this.add_switch_row({
+            key: 'copy-on-selection',
+            title: this.gettext('Copy On Selection'),
+        });
+
         this.connect('realize', this.#realize.bind(this));
     }
 

--- a/schemas/com.github.amezin.ddterm.gschema.xml
+++ b/schemas/com.github.amezin.ddterm.gschema.xml
@@ -5,6 +5,7 @@ SPDX-FileCopyrightText: 2020 Aleksandr Mezin <mezin.alexander@gmail.com>
 SPDX-FileContributor: Mohammad Javad Naderi
 SPDX-FileContributor: Juan M. Cruz-Martinez
 SPDX-FileContributor: Jackson Goode
+SPDX-FileContributor: Mike Lei
 
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
@@ -261,6 +262,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
     </key>
     <key name="detect-urls-news-man" type="b">
       <default>true</default>
+    </key>
+    <key name="copy-on-selection" type="b">
+      <default>false</default>
     </key>
 
     <key name="use-theme-colors" type="b">


### PR DESCRIPTION
This feature was requested in #64, but was closed due to the fact that Vte automatically copies the selected text to the "primary" selection as you said in the [comment](https://github.com/ddterm/gnome-shell-extension-ddterm/issues/64#issuecomment-922246812).

However, the "primary" selection is only usable with the middle click paste action, not the usual <kbd>Ctrl</kbd>+<kbd>V</kbd> keyboard shortcut or any context menu entry that pastes content from the "clipboard" selection.

This PR adds an option to the settings of the extension under the "Text" section. When enabled, the selected text will also be copied to the "clipboard" selection, so it can be easily pasted using the keyboard shortcut or the context menu entry.