### PR TITLE
build: update GNOME 50 support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ applications_dir = datadir / 'applications'
 dbus_service_dir = datadir / 'dbus-1' / 'services'
 
 gjs_req = '>=1.80.0'
-gnome_shell_req = ['>=46.0', '<52']
+gnome_shell_req = ['>=46.0', '<51']
 shell_versions = ['46', '47', '48', '49', '50']
 
 layout = get_option('layout')

--- a/meson.build
+++ b/meson.build
@@ -28,8 +28,8 @@ applications_dir = datadir / 'applications'
 dbus_service_dir = datadir / 'dbus-1' / 'services'
 
 gjs_req = '>=1.80.0'
-gnome_shell_req = ['>=46.0', '<51']
-shell_versions = ['46', '47', '48', '49', '50.beta']
+gnome_shell_req = ['>=46.0', '<52']
+shell_versions = ['46', '47', '48', '49', '50']
 
 layout = get_option('layout')
 


### PR DESCRIPTION
Bump GNOME 50.beta to 50 (stable).

Fully addresses  #1767 