### PR TITLE
npm: ignore scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@
 
 git-tag-version = false
 preid = dev
+ignore-scripts = true


### PR DESCRIPTION
It seems that postinstall scripts are a popular supply chain attack vector. At least once happened with ESLint:

https://security.snyk.io/vuln/SNYK-JS-ESLINTSCOPE-11120

And, at the same time, it seems that they are completely unnecessary.