### PR TITLE
npm: allow git dependencies only in the root `package.json`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,3 +5,4 @@
 git-tag-version = false
 preid = dev
 ignore-scripts = true
+allow-git = root


### PR DESCRIPTION
https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/

> Git dependencies-direct or transitive-can include .npmrc files that override the git executable path. This enables arbitrary code execution during install even when using --ignore-scripts.