### PR TITLE
npm: set `minimum-release-age`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,3 +6,4 @@ git-tag-version = false
 preid = dev
 ignore-scripts = true
 allow-git = root
+minimum-release-age = 3


### PR DESCRIPTION
Match Renovate's `security:minimumReleaseAgeNpm`