### PR TITLE
ci: stop uploading test results to Testspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,39 +516,3 @@ jobs:
             *.pkg.tar.*
             *.log
           if-no-files-found: error
-
-  testspace-publish:
-    needs:
-      - plan
-      - test
-      - archlinux-installed-test
-
-    if: always() && fromJSON(needs.plan.outputs.need-tests) && vars.ENABLE_TESTSPACE
-    runs-on: ubuntu-slim
-    timeout-minutes: 10
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: testspace-com/setup-testspace@5fc620521eddeba83c1c0dd58f5a524adf474c93 # v1.0.8
-        with:
-          domain: ${{ github.repository_owner }}
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: '{report-*.html,junit-*.xml}'
-          merge-multiple: true
-
-      - run: |
-          res=0
-          how="?start"
-
-          for report in junit-*.xml; do
-            name="${report#junit-}"
-            name="${name%.xml}"
-            testspace --verbose push "[$name]./$report" "[$name]+./report-$name.html" "$how" || res="$?"
-            how="?add"
-          done
-
-          testspace --verbose push "?finish"
-          exit "$res"


### PR DESCRIPTION
Reports can be browsed directly on GitHub now.