### PR TITLE
app/notebook: make tab navigation cyclic again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,15 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Renamed settings schema to comply with GNOME Shell extension guidelines:
 [#1888].
-- Incorrectly translated string in Korean translation by [@seuimi]:
-[#1885], [#1886].
+- Fix for Korean translation by [@seuimi]: [#1885], [#1886].
+- Restored cyclic navigation between tabs/pages: [#1898], [#1901].
 
 [#1880]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1880
 [#1885]: https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1885
 [#1886]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1886
 [#1888]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1888
+[#1898]: https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1898
+[#1901]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1901
 
 [@seuimi]: https://github.com/seuimi
 [phlostically]: https://hosted.weblate.org/user/phlostically/

--- a/ddterm/app/notebook.js
+++ b/ddterm/app/notebook.js
@@ -367,11 +367,17 @@ export class Notebook extends Gtk.Box {
     }
 
     #next_tab() {
-        this.view.select_next_page();
+        const { view, n_pages } = this;
+
+        if (n_pages !== 0 && !view.select_next_page())
+            view.set_selected_page(view.get_nth_page(0));
     }
 
     #prev_tab() {
-        this.view.select_previous_page();
+        const { view, n_pages } = this;
+
+        if (n_pages !== 0 && !view.select_previous_page())
+            view.set_selected_page(view.get_nth_page(n_pages - 1));
     }
 
     _page_attached(view, page, _position) {


### PR DESCRIPTION
Turns out, most GNOME apps (at least, terminals) switch to the first tab after you press Ctrl+Page_Down on the last tab.

Shortcuts for moving tabs backward/forward, however, do not cycle.

Fixes https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1898