### PR TITLE
npm: install `eslint-config-gnome` without git

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@eslint/js": "9.39.4",
                 "argparse": "2.0.1",
                 "eslint": "9.39.4",
-                "eslint-config-gnome": "git+https://github.com/ddterm/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51",
+                "eslint-config-gnome": "https://github.com/ddterm/eslint-config-gnome/archive/c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51.tar.gz",
                 "eslint-plugin-import": "2.32.0",
                 "markdown-it": "14.1.1",
                 "markdownlint-cli2": "0.22.1",
@@ -1278,8 +1278,8 @@
         },
         "node_modules/eslint-config-gnome": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/ddterm/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51",
-            "integrity": "sha512-ZrwXjeimccYERRLYlknXY97PWPrQzG1FQdbZLV7Wip9q3I+JfCs7byYHldyh7ixCLH8VVl2cbNfiSEqisq7lSw==",
+            "resolved": "https://github.com/ddterm/eslint-config-gnome/archive/c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51.tar.gz",
+            "integrity": "sha512-GDRPxdFnUXy89UwdH9oLtD2ECCh0n+AucyEQMvOWUJ4WOSOpNr8ek0qXaAxcFanZBjIJeDoPr1wsD5zIB3JsUw==",
             "dev": true,
             "license": "MIT OR LGPL-2.1-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@eslint/js": "9.39.4",
         "argparse": "2.0.1",
         "eslint": "9.39.4",
-        "eslint-config-gnome": "git+https://github.com/ddterm/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51",
+        "eslint-config-gnome": "https://github.com/ddterm/eslint-config-gnome/archive/c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51.tar.gz",
         "eslint-plugin-import": "2.32.0",
         "markdown-it": "14.1.1",
         "markdownlint-cli2": "0.22.1",


### PR DESCRIPTION
Avoid `allow-git` issues and npm "magic" https->ssh replacement.

Also should make integrity checks actually work.