### PR TITLE
settings: add Copy and Paste hardware key defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+- Added `Copy` and `Paste` hardware keys as default terminal copy/paste shortcuts.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,18 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-- Added `Copy` and `Paste` hardware keys as default terminal copy/paste shortcuts.
+- Added `Copy` and `Paste` hardware keys as default terminal copy/paste shortcuts
+by [@ponta0]: [#1915].
 
 ### Changed
 
 ### Removed
 
 ### Fixed
+
+[#1915]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1915
+
+[@ponta0]: https://github.com/ponta0
 
 [Unreleased]: https://github.com/ddterm/gnome-shell-extension-ddterm/compare/v63.0.1...HEAD
 

--- a/schemas/org.gnome.shell.extensions.ddterm.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.ddterm.gschema.xml
@@ -6,6 +6,7 @@ SPDX-FileContributor: Mohammad Javad Naderi
 SPDX-FileContributor: Juan M. Cruz-Martinez
 SPDX-FileContributor: Jackson Goode
 SPDX-FileContributor: Mike Lei
+SPDX-FileContributor: Magnia
 
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
@@ -401,13 +402,13 @@ SPDX-License-Identifier: GPL-3.0-or-later
       <default>false</default>
     </key>
     <key name="shortcut-terminal-copy" type="as">
-      <default><![CDATA[['<Ctrl><Shift>c']]]></default>
+      <default><![CDATA[['<Ctrl><Shift>c', 'Copy']]]></default>
     </key>
     <key name="shortcut-terminal-copy-html" type="as">
       <default><![CDATA[[]]]></default>
     </key>
     <key name="shortcut-terminal-paste" type="as">
-      <default><![CDATA[['<Ctrl><Shift>v']]]></default>
+      <default><![CDATA[['<Ctrl><Shift>v', 'Paste']]]></default>
     </key>
     <key name="shortcut-terminal-select-all" type="as">
       <default><![CDATA[[]]]></default>


### PR DESCRIPTION
## Summary

Add the standard Copy and Paste hardware keys as default terminal copy/paste
shortcuts.

This allows keyboards and key remappers that emit XF86Copy / XF86Paste to use
ddterm's existing terminal copy and paste actions without translating them to
Ctrl+C or Ctrl+V. Ctrl+C therefore remains available for its usual terminal
SIGINT behavior.

GDK exposes these keys as the GTK accelerator names `Copy` and `Paste`.

## Testing

- `git diff --check`
- `glib-compile-schemas --strict --dry-run schemas`
- `meson setup build-dir`
- `ninja -C build-dir bundle`