### PR TITLE
prefs/shortcuts: arrange multiple shortcut lables in a column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,12 @@ by [@ponta0]: [#1915].
 
 ### Fixed
 
+- When multiple keyboard shortcuts are assigned to the same action,
+they are now better visually separated in Preferences dialog: [#1917].
+
 [#1915]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1915
 [#1919]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1919
+[#1917]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1917
 
 [@ponta0]: https://github.com/ponta0
 

--- a/ddterm/pref/shortcuts.js
+++ b/ddterm/pref/shortcuts.js
@@ -310,10 +310,26 @@ class ShortcutRow extends ActionRow {
         GObject.registerClass(this);
     }
 
+    #box;
     #labels;
 
     constructor(params) {
         super(params);
+
+        this.#box = new Gtk.Box({
+            visible: true,
+            orientation: Gtk.Orientation.VERTICAL,
+            homogeneous: true,
+            valign: Gtk.Align.CENTER,
+            spacing: 4,
+            margin_top: 4,
+            margin_bottom: 4,
+        });
+
+        if (this.add_suffix)
+            this.add_suffix(this.#box);
+        else
+            this.add(this.#box);
 
         this.#labels = [];
 
@@ -328,7 +344,7 @@ class ShortcutRow extends ActionRow {
         const n = Math.max(1, value.length);
 
         while (this.#labels.length > n)
-            this.remove(this.#labels.pop());
+            this.#box.remove(this.#labels.pop());
 
         for (let i = 0; i < n; i++) {
             const accelerator = value[i] || null;
@@ -340,15 +356,15 @@ class ShortcutRow extends ActionRow {
 
             const label = new Gtk.ShortcutLabel({
                 visible: true,
+                halign: Gtk.Align.END,
                 disabled_text: this.gettext_domain.gettext('Disabled'),
                 accelerator,
-                valign: Gtk.Align.CENTER,
             });
 
-            if (this.add_suffix)
-                this.add_suffix(label);
+            if (this.#box.append)
+                this.#box.append(label);
             else
-                this.add(label);
+                this.#box.add(label);
 
             this.#labels.push(label);
         }


### PR DESCRIPTION
https://github.com/ddterm/gnome-shell-extension-ddterm/issues/932

From

<img width="1132" height="376" alt="Image" src="https://github.com/user-attachments/assets/46cd3ef5-1bf2-4440-8a9f-e67f263d7d8d" />

to

<img width="1136" height="474" alt="image" src="https://github.com/user-attachments/assets/c5817ec0-5c4b-47ed-84d7-dde9e3049ae9" />

UPD: adjusted margins and spacing a bit
