### PR TITLE
prefs: add "Reset to default value" button to most rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Added `Copy` and `Paste` hardware keys as default terminal copy/paste shortcuts
 by [@ponta0]: [#1915].
+- Added "Reset to default value" button for most settings in Preferences dialog:
+[#1919].
 
 ### Changed
 
@@ -28,6 +30,7 @@ by [@ponta0]: [#1915].
 ### Fixed
 
 [#1915]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1915
+[#1919]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1919
 
 [@ponta0]: https://github.com/ponta0
 

--- a/ddterm/pref/animation.js
+++ b/ddterm/pref/animation.js
@@ -6,7 +6,7 @@ import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 
-import { PreferencesGroup, ScaleRow, ComboTextItem } from './util.js';
+import { PreferencesGroup, ScaleRow, ComboTextItem, add_reset_button } from './util.js';
 
 export class AnimationGroup extends PreferencesGroup {
     static [GObject.GTypeName] = 'DDTermAnimationPreferencesGroup';
@@ -121,6 +121,13 @@ export class AnimationGroup extends PreferencesGroup {
             false
         );
 
+        add_reset_button(
+            this.#show_animation_duration_scale,
+            this.settings,
+            'show-animation-duration',
+            this.gettext_domain
+        );
+
         this.add(this.#show_animation_duration_scale);
 
         this.#hide_animation_combo = this.add_combo_text_row({
@@ -144,6 +151,13 @@ export class AnimationGroup extends PreferencesGroup {
             this.#hide_animation_duration_scale,
             'sensitive',
             false
+        );
+
+        add_reset_button(
+            this.#hide_animation_duration_scale,
+            this.settings,
+            'hide-animation-duration',
+            this.gettext_domain
         );
 
         this.add(this.#hide_animation_duration_scale);

--- a/ddterm/pref/colors.js
+++ b/ddterm/pref/colors.js
@@ -11,6 +11,7 @@ import Gtk from 'gi://Gtk';
 
 import {
     ActionRow,
+    add_reset_button,
     ComboRow,
     PreferencesGroup,
     PreferencesRow,
@@ -429,12 +430,26 @@ export class ColorsGroup extends PreferencesGroup {
             color: this.#color_scheme.colors[0],
         });
 
+        add_reset_button(
+            this.#foreground_color_row,
+            this.settings,
+            'foreground-color',
+            this.gettext_domain
+        );
+
         this.add(this.#foreground_color_row);
 
         this.#background_color_row = ColorRow.create({
             title: this.gettext('Background Color'),
             color: this.#color_scheme.colors[1],
         });
+
+        add_reset_button(
+            this.#background_color_row,
+            this.settings,
+            'background-color',
+            this.gettext_domain
+        );
 
         this.add(this.#background_color_row);
 
@@ -453,6 +468,7 @@ export class ColorsGroup extends PreferencesGroup {
         });
 
         this.settings.bind_writable('bold-color', bold_color_row, 'sensitive', false);
+        add_reset_button(bold_color_row, this.settings, 'bold-color', this.gettext_domain);
         this.#bold_color_expander.add_row(bold_color_row);
 
         this.#cursor_color_expander = this.add_expander_row({
@@ -500,6 +516,20 @@ export class ColorsGroup extends PreferencesGroup {
             cursor_background_color_row,
             'sensitive',
             false
+        );
+
+        add_reset_button(
+            cursor_foreground_color_row,
+            this.settings,
+            'cursor-foreground-color',
+            this.gettext_domain
+        );
+
+        add_reset_button(
+            cursor_background_color_row,
+            this.settings,
+            'cursor-background-color',
+            this.gettext_domain
         );
 
         this.#cursor_color_expander.add_row(cursor_foreground_color_row);
@@ -552,6 +582,20 @@ export class ColorsGroup extends PreferencesGroup {
             false
         );
 
+        add_reset_button(
+            highlight_foreground_color_row,
+            this.settings,
+            'highlight-foreground-color',
+            this.gettext_domain
+        );
+
+        add_reset_button(
+            highlight_background_color_row,
+            this.settings,
+            'highlight-background-color',
+            this.gettext_domain
+        );
+
         this.#highlight_color_expander.add_row(highlight_foreground_color_row);
         this.#highlight_color_expander.add_row(highlight_background_color_row);
 
@@ -586,6 +630,8 @@ export class ColorsGroup extends PreferencesGroup {
             'sensitive',
             false
         );
+
+        add_reset_button(opacity_row, this.settings, 'background-opacity', this.gettext_domain);
 
         const opacity_expander = this.add_expander_row({
             key: 'transparent-background',
@@ -736,6 +782,8 @@ export class ColorsGroup extends PreferencesGroup {
             'sensitive',
             false
         );
+
+        add_reset_button(palette_combo, this.settings, 'palette', this.gettext_domain);
 
         this.add(palette_combo);
 

--- a/ddterm/pref/command.js
+++ b/ddterm/pref/command.js
@@ -5,7 +5,7 @@
 import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 
-import { PreferencesGroup, EntryRow } from './util.js';
+import { PreferencesGroup, EntryRow, add_reset_button } from './util.js';
 
 export class CommandGroup extends PreferencesGroup {
     static [GObject.GTypeName] = 'DDTermCommandPreferencesGroup';
@@ -42,6 +42,13 @@ export class CommandGroup extends PreferencesGroup {
             this.#custom_command_entry,
             'text',
             Gio.SettingsBindFlags.NO_SENSITIVITY
+        );
+
+        add_reset_button(
+            this.#custom_command_entry,
+            this.settings,
+            'custom-command',
+            this.gettext_domain
         );
 
         this.add(this.#custom_command_entry);

--- a/ddterm/pref/scrolling.js
+++ b/ddterm/pref/scrolling.js
@@ -6,7 +6,7 @@ import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 
-import { PreferencesGroup, SpinRow } from './util.js';
+import { add_reset_button, PreferencesGroup, SpinRow } from './util.js';
 
 export class ScrollingGroup extends PreferencesGroup {
     static [GObject.GTypeName] = 'DDTermScrollingPreferencesGroup';
@@ -62,6 +62,13 @@ export class ScrollingGroup extends PreferencesGroup {
             this.#lines_adjustment,
             'value',
             Gio.SettingsBindFlags.NO_SENSITIVITY
+        );
+
+        add_reset_button(
+            this.#lines_row,
+            this.settings,
+            'scrollback-lines',
+            this.gettext_domain
         );
 
         this.add(this.#lines_row);

--- a/ddterm/pref/shortcuts.js
+++ b/ddterm/pref/shortcuts.js
@@ -10,7 +10,7 @@ import Gio from 'gi://Gio';
 import Gdk from 'gi://Gdk';
 import Gtk from 'gi://Gtk';
 
-import { PreferencesGroup, ActionRow } from './util.js';
+import { PreferencesGroup, ActionRow, add_reset_button } from './util.js';
 
 const IS_GTK3 = Gtk.get_major_version() === 3;
 
@@ -433,6 +433,7 @@ class ShortcutGroup extends PreferencesGroup {
         });
 
         this.settings.bind(key, row, 'value', flags);
+        add_reset_button(row, this.settings, key, this.gettext_domain);
 
         const conflict_handler = this.connect('accelerator-set', (self, keyval, modifiers) => {
             row.remove_conflict(keyval, modifiers);

--- a/ddterm/pref/util.js
+++ b/ddterm/pref/util.js
@@ -16,6 +16,49 @@ export const {
     ActionRow,
 } = AdwOrHdy;
 
+export function add_reset_button(row, settings, key, gettext_domain) {
+    const button = Gtk.Button.new_from_icon_name.length === 1
+        ? Gtk.Button.new_from_icon_name('edit-clear')
+        : Gtk.Button.new_from_icon_name('edit-clear', Gtk.IconSize.BUTTON);
+
+    button.set_tooltip_text(gettext_domain.gettext('Reset to default value'));
+    button.set_valign(Gtk.Align.CENTER);
+    button.set_hexpand(false);
+    button.set_vexpand(false);
+
+    if (button.set_has_frame)
+        button.set_has_frame(false);
+    else
+        button.set_relief(Gtk.ReliefStyle.NONE);
+
+    if (row.add_suffix)
+        row.add_suffix(button);
+    else
+        row.add(button);
+
+    settings.bind_writable(key, button, 'sensitive', false);
+
+    row.connect('realize', () => {
+        const changed = settings.connect(`changed::${key}`, () => {
+            button.visible = settings.get_user_value(key) !== null;
+        });
+
+        const clicked = button.connect('clicked', () => {
+            settings.reset(key);
+        });
+
+        const unrealize = row.connect('unrealize', () => {
+            row.disconnect(unrealize);
+            settings.disconnect(changed);
+            button.disconnect(clicked);
+        });
+
+        button.visible = settings.get_user_value(key) !== null;
+    });
+
+    return button;
+}
+
 export const SwitchRow = AdwOrHdy.SwitchRow ?? class extends ActionRow {
     static [GObject.GTypeName] = 'DDTermSwitchRow';
 
@@ -86,6 +129,7 @@ function create_switch_row({
     settings,
     key,
     flags = Gio.SettingsBindFlags.DEFAULT,
+    gettext_domain,
     ...params
 }) {
     const row = new SwitchRow({
@@ -95,6 +139,7 @@ function create_switch_row({
     });
 
     settings.bind(key, row, 'active', flags);
+    add_reset_button(row, settings, key, gettext_domain);
 
     return row;
 }
@@ -390,6 +435,7 @@ export class ComboTextRow extends ComboRow {
         key,
         model,
         flags = Gio.SettingsBindFlags.DEFAULT,
+        gettext_domain,
         ...params
     }) {
         if (model && !(model instanceof GObject.Object))
@@ -404,6 +450,7 @@ export class ComboTextRow extends ComboRow {
         row.bind_name_model(model);
 
         settings.bind(key, row, 'value', flags);
+        add_reset_button(row, settings, key, gettext_domain);
 
         return row;
     }
@@ -569,6 +616,12 @@ export class ExpanderRow extends AdwOrHdy.ExpanderRow {
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             Gio.Settings
         ),
+        'gettext-domain': GObject.ParamSpec.jsobject(
+            'gettext-domain',
+            null,
+            null,
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY
+        ),
     };
 
     static {
@@ -576,7 +629,11 @@ export class ExpanderRow extends AdwOrHdy.ExpanderRow {
     }
 
     add_switch_row(params) {
-        const row = create_switch_row({ settings: this.settings, ...params });
+        const row = create_switch_row({
+            settings: this.settings,
+            gettext_domain: this.gettext_domain,
+            ...params,
+        });
 
         this.add_row(row);
 
@@ -584,7 +641,11 @@ export class ExpanderRow extends AdwOrHdy.ExpanderRow {
     }
 
     add_combo_text_row(params) {
-        const row = ComboTextRow.create({ settings: this.settings, ...params });
+        const row = ComboTextRow.create({
+            settings: this.settings,
+            gettext_domain: this.gettext_domain,
+            ...params,
+        });
 
         this.add_row(row);
 
@@ -602,6 +663,7 @@ export class ExpanderRow extends AdwOrHdy.ExpanderRow {
         settings,
         key,
         flags = Gio.SettingsBindFlags.DEFAULT,
+        gettext_domain,
         ...params
     }) {
         const row = new ExpanderRow({
@@ -609,11 +671,14 @@ export class ExpanderRow extends AdwOrHdy.ExpanderRow {
             visible: true,
             use_underline: true,
             show_enable_switch: Boolean(key),
+            gettext_domain,
             ...params,
         });
 
-        if (key)
+        if (key) {
             settings.bind(key, row, 'enable-expansion', flags);
+            add_reset_button(row, settings, key, gettext_domain);
+        }
 
         return row;
     }
@@ -654,7 +719,11 @@ export class PreferencesGroup extends AdwOrHdy.PreferencesGroup {
     }
 
     add_switch_row(params) {
-        const row = create_switch_row({ settings: this.settings, ...params });
+        const row = create_switch_row({
+            settings: this.settings,
+            gettext_domain: this.gettext_domain,
+            ...params,
+        });
 
         this.add(row);
 
@@ -662,7 +731,11 @@ export class PreferencesGroup extends AdwOrHdy.PreferencesGroup {
     }
 
     add_combo_text_row(params) {
-        const row = ComboTextRow.create({ settings: this.settings, ...params });
+        const row = ComboTextRow.create({
+            settings: this.settings,
+            gettext_domain: this.gettext_domain,
+            ...params,
+        });
 
         this.add(row);
 
@@ -670,7 +743,11 @@ export class PreferencesGroup extends AdwOrHdy.PreferencesGroup {
     }
 
     add_expander_row(params) {
-        const row = ExpanderRow.create({ settings: this.settings, ...params });
+        const row = ExpanderRow.create({
+            settings: this.settings,
+            gettext_domain: this.gettext_domain,
+            ...params,
+        });
 
         this.add(row);
 


### PR DESCRIPTION
GNOME Control Center shows a similar button for customized keyboard shortcuts. In ddterm it'll appear on all preferences rows.

<img width="1137" height="156" alt="Screenshot From 2026-05-18 01-06-51" src="https://github.com/user-attachments/assets/875c8ac4-4fc9-4e65-897e-83e65a441598" />
