### PR TITLE
prefs: use `.add_action()` to add reset button to `Handy.ExpanderRow`

### DIFF
--- a/ddterm/pref/util.js
+++ b/ddterm/pref/util.js
@@ -33,6 +33,8 @@ export function add_reset_button(row, settings, key, gettext_domain) {
 
     if (row.add_suffix)
         row.add_suffix(button);
+    else if (row.add_action) // For Handy.ExpanderRow - otherwise gets added as a child row
+        row.add_action(button);
     else
         row.add(button);
 


### PR DESCRIPTION
Otherwise it gets added as a child row.