### PR TITLE
extension/wm: fix maximized window placement on mutter 50.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Fixed
+
+- Window placement on Mutter 50.2: [#1955].
+
+[#1955]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1955
+
+[Unreleased]: https://github.com/ddterm/gnome-shell-extension-ddterm/compare/v63.1.0...HEAD
+
 ## [63.1.0] - 2026-06-02
 
 ### Added

--- a/ddterm/shell/wm.js
+++ b/ddterm/shell/wm.js
@@ -135,6 +135,9 @@ export const WindowManager = GObject.registerClass({
             ([signal, callback]) => this.geometry.connect(signal, callback)
         );
 
+        if (!this.#actor.visible && this.#client_type === Meta.WindowClientType.WAYLAND)
+            this.window.move_to_monitor(this.geometry.monitor_index);
+
         this.#window_handlers = Object.entries({
             'unmanaged': () => {
                 this.disable();


### PR DESCRIPTION
There seem to be an issue with maximized windows moving to wrong monitor on mutter 50.2. Call `window.move_to_monitor()` to fix it.