### PR TITLE
extension/wlclipboard: make /proc/pid/cmdline read async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Fixed
 
 - Window placement on Mutter 50.2: [#1955].
+- Prevent blocking on `/proc/${pid}/cmdline` read in wl-clipboard integration:
+[#1954], [#1958].
 
+[#1954]: https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1954
 [#1955]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1955
+[#1958]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1958
 
 [Unreleased]: https://github.com/ddterm/gnome-shell-extension-ddterm/compare/v63.1.0...HEAD
 

--- a/ddterm/shell/extension.js
+++ b/ddterm/shell/extension.js
@@ -354,6 +354,8 @@ class EnabledExtension {
             this.window_matcher.disable();
         });
 
+        this.window_matcher.check_all_windows();
+
         this.app_control = new AppControl({
             service: this.service,
             window_matcher: this.window_matcher,

--- a/ddterm/shell/windowmatch.js
+++ b/ddterm/shell/windowmatch.js
@@ -9,8 +9,10 @@ import Meta from 'gi://Meta';
 
 import { Service } from './service.js';
 
-export const WindowMatchGeneric = GObject.registerClass({
-    Properties: {
+export class WindowMatchGeneric extends GObject.Object {
+    static [GObject.GTypeName] = 'DDTermWindowMatchGeneric';
+
+    static [GObject.properties] = {
         'display': GObject.ParamSpec.object(
             'display',
             null,
@@ -25,16 +27,21 @@ export const WindowMatchGeneric = GObject.registerClass({
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             GObject.type_from_name('GStrv')
         ),
-    },
-    Signals: {
+    };
+
+    static [GObject.signals] = {
         'disabled': {},
-    },
-}, class DDTermWindowMatchGeneric extends GObject.Object {
-    _init(params) {
-        super._init(params);
+    };
+
+    static {
+        GObject.registerClass(this);
+    }
+
+    constructor(params) {
+        super(params);
 
         let created_handler = this.display.connect('window-created', (_, win) => {
-            this._watch_window(win);
+            this.#watch_window(win);
         });
 
         this.connect('disabled', () => {
@@ -43,16 +50,18 @@ export const WindowMatchGeneric = GObject.registerClass({
                 created_handler = null;
             }
         });
-
-        for (const win of this.display.list_all_windows())
-            this._watch_window(win);
     }
 
     disable() {
         this.emit('disabled');
     }
 
-    _watch_window(win) {
+    check_all_windows() {
+        for (const win of this.display.list_all_windows())
+            this.#watch_window(win);
+    }
+
+    #watch_window(win) {
         if (this.check_window(win) === GLib.SOURCE_REMOVE)
             return;
 
@@ -76,10 +85,12 @@ export const WindowMatchGeneric = GObject.registerClass({
 
         check();
     }
-});
+}
 
-export const WindowMatch = GObject.registerClass({
-    Properties: {
+export class WindowMatch extends WindowMatchGeneric {
+    static [GObject.GTypeName] = 'DDTermWindowMatch';
+
+    static [GObject.properties] = {
         'service': GObject.ParamSpec.object(
             'service',
             null,
@@ -115,12 +126,17 @@ export const WindowMatch = GObject.registerClass({
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             null
         ),
-    },
-}, class DDTermWindowMatch extends WindowMatchGeneric {
-    _init(params) {
-        this._window = null;
+    };
 
-        super._init({
+    static {
+        GObject.registerClass(this);
+    }
+
+    #window = null;
+    #window_untrack_handler;
+
+    constructor(params) {
+        super({
             track_signals: [
                 'notify::gtk-application-id',
                 'notify::gtk-window-object-path',
@@ -129,20 +145,20 @@ export const WindowMatch = GObject.registerClass({
         });
 
         this.connect('disabled', () => {
-            this._untrack_window();
+            this.#untrack_window();
         });
     }
 
     get current_window() {
-        return this._window;
+        return this.#window;
     }
 
     get has_window() {
-        return Boolean(this._window);
+        return Boolean(this.#window);
     }
 
     check_window(win) {
-        if (win === this._window)
+        if (win === this.#window)
             return GLib.SOURCE_REMOVE;
 
         if (!this.service.owns_window(win)) {
@@ -178,11 +194,11 @@ export const WindowMatch = GObject.registerClass({
         this.freeze_notify();
 
         try {
-            this._untrack_window();
+            this.#untrack_window();
 
-            this._window = win;
-            this._window_untrack_handler = this._window.connect('unmanaged', () => {
-                this._untrack_window();
+            this.#window = win;
+            this.#window_untrack_handler = this.#window.connect('unmanaged', () => {
+                this.#untrack_window();
             });
 
             this.notify('has-window');
@@ -194,14 +210,14 @@ export const WindowMatch = GObject.registerClass({
         return GLib.SOURCE_REMOVE;
     }
 
-    _untrack_window() {
-        if (!this._window)
+    #untrack_window() {
+        if (!this.#window)
             return;
 
-        this._window.disconnect(this._window_untrack_handler);
-        this._window_untrack_handler = null;
-        this._window = null;
+        this.#window.disconnect(this.#window_untrack_handler);
+        this.#window_untrack_handler = null;
+        this.#window = null;
         this.notify('has-window');
         this.notify('current-window');
     }
-});
+}

--- a/ddterm/shell/windowmatch.js
+++ b/ddterm/shell/windowmatch.js
@@ -5,6 +5,7 @@
 
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
 import Meta from 'gi://Meta';
 
 import { Service } from './service.js';
@@ -62,17 +63,31 @@ export class WindowMatchGeneric extends GObject.Object {
     }
 
     #watch_window(win) {
-        if (this.check_window(win) === GLib.SOURCE_REMOVE)
-            return;
+        let cancellable;
 
         const disconnect = () => {
-            window_handlers.forEach(handler => win.disconnect(handler));
-            this.disconnect(disable_handler);
+            if (disable_handler) {
+                this.disconnect(disable_handler);
+                disable_handler = null;
+            }
+
+            while (window_handlers.length > 0)
+                win.disconnect(window_handlers.pop());
+
+            cancellable?.cancel();
         };
 
-        const check = () => {
-            if (this.check_window(win) === GLib.SOURCE_REMOVE)
-                disconnect();
+        const check = async () => {
+            try {
+                cancellable?.cancel();
+                cancellable = Gio.Cancellable.new();
+
+                if (await this.check_window(win, cancellable) === GLib.SOURCE_REMOVE)
+                    disconnect();
+            } catch (ex) {
+                if (!ex.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED))
+                    logError(ex);
+            }
         };
 
         const window_handlers = [
@@ -81,7 +96,7 @@ export class WindowMatchGeneric extends GObject.Object {
             win.connect('unmanaged', disconnect),
         ];
 
-        const disable_handler = this.connect('disabled', disconnect);
+        let disable_handler = this.connect('disabled', disconnect);
 
         check();
     }

--- a/ddterm/shell/wlclipboard.js
+++ b/ddterm/shell/wlclipboard.js
@@ -4,11 +4,12 @@
 
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
 import Meta from 'gi://Meta';
 
 import { WindowMatchGeneric } from './windowmatch.js';
 
-export function is_wlclipboard(win) {
+export async function is_wlclipboard(win, cancellable = null) {
     if (!win)
         return false;
 
@@ -21,11 +22,26 @@ export function is_wlclipboard(win) {
     const pid = win.get_pid();
 
     try {
-        const [, bytes] = GLib.file_get_contents(`/proc/${pid}/cmdline`);
+        const file = Gio.File.new_for_path(`/proc/${pid}/cmdline`);
+
+        const [, bytes] = await new Promise((resolve, reject) => {
+            file.load_contents_async(cancellable, (source, result) => {
+                try {
+                    resolve(source.load_contents_finish(result));
+                } catch (ex) {
+                    reject(ex);
+                }
+            });
+        });
+
         const argv0_bytes = bytes.slice(0, bytes.indexOf(0));
         const argv0 = new TextDecoder().decode(argv0_bytes);
+
         return ['wl-copy', 'wl-paste'].includes(GLib.path_get_basename(argv0));
-    } catch {
+    } catch (ex) {
+        cancellable?.set_error_if_cancelled();
+        logError(ex);
+
         return false;
     }
 }
@@ -47,20 +63,23 @@ export class WlClipboardActivator extends WindowMatchGeneric {
         });
     }
 
-    check_window(win) {
+    async check_window(win, cancellable) {
         if (win.get_client_type() !== Meta.WindowClientType.WAYLAND)
             return GLib.SOURCE_REMOVE;
 
         if (!win.title)
             return GLib.SOURCE_CONTINUE;
 
-        if (!is_wlclipboard(win))
+        if (!await is_wlclipboard(win, cancellable))
             return GLib.SOURCE_REMOVE;
+
+        cancellable.set_error_if_cancelled();
 
         if (win.is_hidden())
             return GLib.SOURCE_CONTINUE;
 
         win.focus(global.get_current_time());
+
         return GLib.SOURCE_REMOVE;
     }
 }

--- a/ddterm/shell/wlclipboard.js
+++ b/ddterm/shell/wlclipboard.js
@@ -9,6 +9,77 @@ import Meta from 'gi://Meta';
 
 import { WindowMatchGeneric } from './windowmatch.js';
 
+function read_async(path, cancellable) {
+    return new Promise((resolve, reject) => {
+        const file = Gio.File.new_for_path(path);
+
+        file.load_contents_async(cancellable, (source, result) => {
+            try {
+                resolve(source.load_contents_finish(result));
+            } catch (ex) {
+                reject(ex);
+            }
+        });
+    });
+}
+
+function wait_cancellable(promise, cancellable) {
+    if (!cancellable)
+        return promise;
+
+    cancellable.set_error_if_cancelled();
+
+    let cancel_handler;
+
+    return new Promise((resolve, reject) => {
+        cancel_handler = cancellable.connect(source => {
+            try {
+                source.set_error_if_cancelled();
+            } catch (ex) {
+                reject(ex);
+            }
+        });
+
+        promise.then(resolve, reject);
+    }).finally(() => {
+        cancellable.disconnect(cancel_handler);
+    });
+}
+
+let read_locks = null;
+
+// Async file read isn't really interruptible, it's just a blocking read()
+// in a thread. So keep a lock per path in progress, to prevent stacking
+// of read tasks for the same path in the thread pool.
+async function read_async_locking(path, cancellable) {
+    for (let lock = read_locks?.get(path); lock; lock = read_locks?.get(path)) {
+        // eslint-disable-next-line no-await-in-loop
+        await wait_cancellable(lock, cancellable);
+    }
+
+    let unlock;
+
+    const lock = new Promise(resolve => {
+        unlock = resolve;
+    });
+
+    if (!read_locks)
+        read_locks = new Map();
+
+    read_locks.set(path, lock);
+
+    try {
+        return await read_async(path, cancellable);
+    } finally {
+        read_locks.delete(path);
+
+        if (read_locks.size === 0)
+            read_locks = null;
+
+        unlock();
+    }
+}
+
 export async function is_wlclipboard(win, cancellable = null) {
     if (!win)
         return false;
@@ -22,18 +93,7 @@ export async function is_wlclipboard(win, cancellable = null) {
     const pid = win.get_pid();
 
     try {
-        const file = Gio.File.new_for_path(`/proc/${pid}/cmdline`);
-
-        const [, bytes] = await new Promise((resolve, reject) => {
-            file.load_contents_async(cancellable, (source, result) => {
-                try {
-                    resolve(source.load_contents_finish(result));
-                } catch (ex) {
-                    reject(ex);
-                }
-            });
-        });
-
+        const [, bytes] = await read_async_locking(`/proc/${pid}/cmdline`, cancellable);
         const argv0_bytes = bytes.slice(0, bytes.indexOf(0));
         const argv0 = new TextDecoder().decode(argv0_bytes);
 

--- a/ddterm/shell/wlclipboard.js
+++ b/ddterm/shell/wlclipboard.js
@@ -30,10 +30,15 @@ export function is_wlclipboard(win) {
     }
 }
 
-export const WlClipboardActivator = GObject.registerClass({
-}, class DDTermWlClipboardActivator extends WindowMatchGeneric {
-    _init(params) {
-        super._init({
+export class WlClipboardActivator extends WindowMatchGeneric {
+    static [GObject.GTypeName] = 'DDTermWlClipboardActivator';
+
+    static {
+        GObject.registerClass(this);
+    }
+
+    constructor(params) {
+        super({
             track_signals: [
                 'notify::title',
                 'shown',
@@ -58,4 +63,4 @@ export const WlClipboardActivator = GObject.registerClass({
         win.focus(global.get_current_time());
         return GLib.SOURCE_REMOVE;
     }
-});
+}

--- a/ddterm/shell/wm.js
+++ b/ddterm/shell/wm.js
@@ -91,6 +91,7 @@ export const WindowManager = GObject.registerClass({
     #map_handler;
     #maximized_handler;
     #focus_window_handler;
+    #focus_window_check_cancellable;
     #geometry_fixup_handlers;
     #wl_clipboard_activator;
 
@@ -274,23 +275,37 @@ export const WindowManager = GObject.registerClass({
         this.disable();
     }
 
-    #hide_when_focus_lost() {
-        if (this.window.is_hidden())
-            return;
+    async #hide_when_focus_lost() {
+        try {
+            this.#focus_window_check_cancellable?.cancel();
 
-        const win = global.display.focus_window;
-        if (this.window === win)
-            return;
-
-        if (win) {
-            if (this.window.is_ancestor_of_transient(win))
+            if (this.window.is_hidden())
                 return;
 
-            if (is_wlclipboard(win))
+            const win = global.display.focus_window;
+
+            if (this.window === win)
                 return;
+
+            if (win) {
+                if (this.window.is_ancestor_of_transient(win))
+                    return;
+
+                const cancellable = Gio.Cancellable.new();
+
+                this.#focus_window_check_cancellable = cancellable;
+
+                if (await is_wlclipboard(win, cancellable))
+                    return;
+
+                cancellable.set_error_if_cancelled();
+            }
+
+            this.emit('hide-request');
+        } catch (ex) {
+            if (!ex.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED))
+                logError(ex);
         }
-
-        this.emit('hide-request');
     }
 
     #setup_hide_when_focus_lost() {
@@ -299,8 +314,10 @@ export const WindowManager = GObject.registerClass({
             this.#focus_window_handler = null;
         }
 
-        if (!this.settings.get_boolean('hide-when-focus-lost'))
+        if (!this.settings.get_boolean('hide-when-focus-lost')) {
+            this.#focus_window_check_cancellable?.cancel();
             return;
+        }
 
         this.#focus_window_handler = global.display.connect(
             'notify::focus-window',
@@ -645,6 +662,8 @@ export const WindowManager = GObject.registerClass({
             global.display.disconnect(this.#focus_window_handler);
             this.#focus_window_handler = null;
         }
+
+        this.#focus_window_check_cancellable?.cancel();
 
         if (this.#map_animation_override_handler) {
             global.window_manager.disconnect(this.#map_animation_override_handler);


### PR DESCRIPTION
Reading `/proc/<pid>/cmdline` can block if the target process is in uninterruptible sleep.

Also requested during review on extensions.gnome.org: https://extensions.gnome.org/review/71405

https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1954