### PR TITLE
tests: take `ID_LIKE` into account when checking os ids

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,17 +420,17 @@ def global_environment(container, request):
 
 
 @pytest.fixture(scope='session')
-def os_id(process_launcher):
+def os_ids(process_launcher):
     return process_launcher.run(
         'sh',
         '-c',
-        '. /etc/os-release && echo $ID',
+        '. /etc/os-release && echo $ID $ID_LIKE',
         stdout=subprocess.PIPE
-    ).stdout.rstrip().decode()
+    ).stdout.decode().split()
 
 
 @pytest.fixture(scope='session')
-def sys_package(container, os_id, request):
+def sys_package(container, os_ids, request):
     sys_package = request.config.option.sys_package
 
     if not sys_package:
@@ -438,11 +438,11 @@ def sys_package(container, os_id, request):
 
     process_launcher = procutil.ContainerExecLauncher(container_id=container, user=0)
 
-    if os_id == 'arch':
+    if 'arch' in os_ids:
         process_launcher.run('pacman', '-U', '--noconfirm', str(sys_package))
 
     else:
-        raise Exception(f"Don't know how to install packages on {os_id}")
+        raise Exception(f"Don't know how to install packages on {os_ids!r}")
 
     return sys_package
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -272,8 +272,8 @@ class GnomeSessionFixtures:
         )
 
     @pytest.fixture(scope='class')
-    def has_x11(self, process_launcher, os_id, request):
-        if os_id == 'centos':
+    def has_x11(self, process_launcher, os_ids, request):
+        if 'rhel' in os_ids:
             return False
 
         result = process_launcher.run(
@@ -545,11 +545,16 @@ class GnomeSessionFixtures:
                 extension_test_hook.wait_property('HasWindow', False)
 
     @pytest.fixture(scope='class')
-    def ignored_log_issues(self, container, os_id):
+    def ignored_log_issues(self, container, os_ids):
         if not container:
             return IGNORED_LOG_ISSUES
 
-        return IGNORED_LOG_ISSUES_BY_OS.get(os_id, IGNORED_LOG_ISSUES)
+        for os_id in os_ids:
+            issues = IGNORED_LOG_ISSUES_BY_OS.get(os_id)
+            if issues is not None:
+                return issues
+
+        return IGNORED_LOG_ISSUES
 
     @pytest.fixture
     def check_log(self, caplog, ignored_log_issues):


### PR DESCRIPTION
Disables (broken) X11 session on AlmaLinux.