### PR TITLE
app/window: fix crash splitting a single-tab pane

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Maximilien Richer (https://github.com/halfa)
 Jing Yen (https://github.com/JingYenLoh)
 Ivan Peshekhonov (https://github.com/vancomm)
 Anton Leontiev (https://github.com/bunder)
+Finn van Riper (https://github.com/van-riper)
 
 # Artwork by:
 Aleksandr Mezin <mezin.alexander@gmail.com> (https://github.com/amezin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Potential failure in desktop entry and D-Bus service file installation:
 [#1984].
 - Chinese translation improvements by [@flytothehighest]: [#1987].
+- Crash (`signal 11`) when splitting a pane containing only a single tab,
+ultimately caused by a use-after-free in libhandy's `HdyTabBox`.
 
 [#1984]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1984
 [#1987]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1987

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,15 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Potential failure in desktop entry and D-Bus service file installation:
 [#1984].
 - Chinese translation improvements by [@flytothehighest]: [#1987].
-- Crash (`signal 11`) when splitting a pane containing only a single tab,
-ultimately caused by a use-after-free in libhandy's `HdyTabBox`.
+- Potential crash fix when splitting a pane containing only one tab
+by [@van-riper]: [#1991].
 
 [#1984]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1984
 [#1987]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1987
+[#1991]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1991
 
 [@flytothehighest]: https://github.com/flytothehighest
+[@van-riper]: https://github.com/van-riper
 
 [Unreleased]: https://github.com/ddterm/gnome-shell-extension-ddterm/compare/v63.2.0...HEAD
 

--- a/ddterm/app/appwindow.js
+++ b/ddterm/app/appwindow.js
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2020 Aleksandr Mezin <mezin.alexander@gmail.com>
 // SPDX-FileContributor: Juan M. Cruz-Martinez
 // SPDX-FileContributor: Jackson Goode
+// SPDX-FileContributor: Finn van Riper
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -542,9 +543,8 @@ export class AppWindow extends Gtk.ApplicationWindow {
         if (notebook.n_pages > 1) {
             notebook.emit('move-to-other-pane', page);
         } else {
-            const new_page = notebook.new_page();
-            notebook.emit('move-to-other-pane', new_page);
-            new_page.spawn();
+            const dest = notebook === this.notebook1 ? this.notebook2 : this.notebook1;
+            dest.new_page().spawn();
         }
     }
 


### PR DESCRIPTION
Splitting a single-tab pane used to create a new page and immediately move it to the other pane. On libhandy v1.8.3, the immediate detach frees the tab while `HdyTabBox` still references it and causes the whole app to crash on the next allocation. Could be wrong but this is probably a result of #1766 

I'm on Fedora 44 Silverblue, and the exact error popup notification I got is as follows:

> Child process killed by signal 11
>
>  Using GtkSettings:gtk-application-prefer-dark-theme together with HdyStyleManager is unsupported. Please use HdyStyleManager:color-scheme instead.

This fix creates the new page directly in the destination notebook, so no transfer happens and `HdyTabBox` never holds a stale pointer.