### PR TITLE
app/notebook: wrap tab bar in a container with opaque background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Potential failure in desktop entry and D-Bus service file installation:
 [#1984].
+- Transparent tab bar with custom themes: [#1997], [#2003], [#2000].
 - Chinese translation improvements by [@flytothehighest]: [#1987].
 - Potential crash fix when splitting a pane containing only one tab
 by [@van-riper]: [#1991].
@@ -27,6 +28,9 @@ by [@van-riper]: [#1991].
 [#1984]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1984
 [#1987]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1987
 [#1991]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/1991
+[#1997]: https://github.com/ddterm/gnome-shell-extension-ddterm/issues/1997
+[#2003]: https://github.com/ddterm/gnome-shell-extension-ddterm/issues/2003
+[#2000]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/2000
 
 [@flytothehighest]: https://github.com/flytothehighest
 [@van-riper]: https://github.com/van-riper

--- a/ddterm/app/notebook.js
+++ b/ddterm/app/notebook.js
@@ -577,12 +577,12 @@ export class Notebook extends Gtk.Box {
     #update_tab_pos() {
         switch (this.tab_pos) {
         case Gtk.PositionType.BOTTOM:
-            this.reorder_child(this._bar, -1);
+            this.reorder_child(this.view, 0);
             this._tab_switch_button.direction = Gtk.ArrowType.UP;
             break;
 
         case Gtk.PositionType.TOP:
-            this.reorder_child(this._bar, 0);
+            this.reorder_child(this.view, -1);
             this._tab_switch_button.direction = Gtk.ArrowType.DOWN;
             break;
 

--- a/ddterm/app/ui/notebook.ui
+++ b/ddterm/app/ui/notebook.ui
@@ -132,42 +132,25 @@ SPDX-License-Identifier: GPL-3.0-or-later
       </packing>
     </child>
     <child>
-      <object class="HdyTabBar" id="bar">
+      <object class="GtkBox" id="bar_container">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
-        <property name="autohide">False</property>
-        <property name="view">view</property>
-        <property name="expand-tabs" bind-source="DDTermNotebook" bind-property="tab-expand" bind-flags="sync-create|bidirectional"/>
         <style>
           <class name="background"/>
         </style>
-        <child type="start">
-          <object class="GtkButton" id="new_tab_front_button">
-            <property name="visible" bind-source="DDTermNotebook" bind-property="show-new-tab-front-button" bind-flags="sync-create|bidirectional"/>
-            <property name="focus_on_click">False</property>
-            <property name="relief">none</property>
-            <property name="tooltip_text" translatable="yes">New Tab (First)</property>
-            <property name="action_name">notebook.new-tab-front</property>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="icon_name">list-add</property>
-                <property name="icon_size">1</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child type="end">
-          <object class="GtkBox" id="end_action_box">
+        <child>
+          <object class="HdyTabBar" id="bar">
             <property name="visible">True</property>
-            <property name="spacing">0</property>
-            <property name="orientation">horizontal</property>
-            <child>
-              <object class="GtkButton" id="new_tab_button">
-                <property name="visible" bind-source="DDTermNotebook" bind-property="show-new-tab-button" bind-flags="sync-create|bidirectional"/>
+            <property name="autohide">False</property>
+            <property name="view">view</property>
+            <property name="expand-tabs" bind-source="DDTermNotebook" bind-property="tab-expand" bind-flags="sync-create|bidirectional"/>
+            <child type="start">
+              <object class="GtkButton" id="new_tab_front_button">
+                <property name="visible" bind-source="DDTermNotebook" bind-property="show-new-tab-front-button" bind-flags="sync-create|bidirectional"/>
                 <property name="focus_on_click">False</property>
                 <property name="relief">none</property>
-                <property name="tooltip_text" translatable="yes">New Tab (Last)</property>
-                <property name="action_name">notebook.new-tab</property>
+                <property name="tooltip_text" translatable="yes">New Tab (First)</property>
+                <property name="action_name">notebook.new-tab-front</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
@@ -177,12 +160,35 @@ SPDX-License-Identifier: GPL-3.0-or-later
                 </child>
               </object>
             </child>
-            <child>
-              <object class="GtkMenuButton" id="tab_switch_button">
-                <property name="visible" bind-source="DDTermNotebook" bind-property="show-tab-switch-popup" bind-flags="sync-create|bidirectional"/>
-                <property name="focus_on_click">False</property>
-                <property name="relief">none</property>
-                <property name="use_popover">False</property>
+            <child type="end">
+              <object class="GtkBox" id="end_action_box">
+                <property name="visible">True</property>
+                <property name="spacing">0</property>
+                <property name="orientation">horizontal</property>
+                <child>
+                  <object class="GtkButton" id="new_tab_button">
+                    <property name="visible" bind-source="DDTermNotebook" bind-property="show-new-tab-button" bind-flags="sync-create|bidirectional"/>
+                    <property name="focus_on_click">False</property>
+                    <property name="relief">none</property>
+                    <property name="tooltip_text" translatable="yes">New Tab (Last)</property>
+                    <property name="action_name">notebook.new-tab</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="icon_name">list-add</property>
+                        <property name="icon_size">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkMenuButton" id="tab_switch_button">
+                    <property name="visible" bind-source="DDTermNotebook" bind-property="show-tab-switch-popup" bind-flags="sync-create|bidirectional"/>
+                    <property name="focus_on_click">False</property>
+                    <property name="relief">none</property>
+                    <property name="use_popover">False</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>


### PR DESCRIPTION
It seems that with some themes the tab bar background becomes transparent, regardless of the `background` css class.

Fixes https://github.com/ddterm/gnome-shell-extension-ddterm/issues/2003