### PR TITLE
tests: ignore wrong `GLib.unix_signal_add_full()` deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ log_date_format = %H:%M:%S
 filterwarnings =
     ignore:'asyncio.get_event_loop_policy' is deprecated and slated for removal in Python 3.16:DeprecationWarning
     ignore:'asyncio.AbstractEventLoopPolicy' is deprecated and slated for removal in Python 3.16:DeprecationWarning
+    # https://gitlab.gnome.org/GNOME/pygobject/-/work_items/757
+    ignore:GLib.unix_signal_add_full is deprecated; use GLibUnix.signal_add_full instead:DeprecationWarning


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/pygobject/-/work_items/757