### PR TITLE
prefs/animation: use subtitle in combo box rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
+- Animation description is now fully displayed in preferences dialog:
+[#2035].
+
+[#2035]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/2035
+
 [Unreleased]: https://github.com/ddterm/gnome-shell-extension-ddterm/compare/v63.2.2...HEAD
 
 ## [63.2.2] - 2026-06-25

--- a/ddterm/pref/animation.js
+++ b/ddterm/pref/animation.js
@@ -105,6 +105,7 @@ export class AnimationGroup extends PreferencesGroup {
             title: this.gettext('_Show Animation'),
             model: animations,
             flags: Gio.SettingsBindFlags.NO_SENSITIVITY,
+            use_subtitle: true,
         });
 
         this.#show_animation_duration_scale = new ScaleRow({
@@ -137,6 +138,7 @@ export class AnimationGroup extends PreferencesGroup {
             title: this.gettext('_Hide Animation'),
             model: animations,
             flags: Gio.SettingsBindFlags.NO_SENSITIVITY,
+            use_subtitle: true,
         });
 
         this.#hide_animation_duration_scale = new ScaleRow({


### PR DESCRIPTION
Animation type description can be really long, it can be fully displayed only as a subtitle.