### PR TITLE
tests: drop old Alpine releases (GNOME is not supported)

### DIFF
--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -8,15 +8,6 @@
 # Or 'tox -e images pull'.
 
 services:
-  alpine-3.21:
-    image: ghcr.io/ddterm/gnome-shell-image/alpine-3.21:2026.07.04.0
-
-  alpine-3.22:
-    image: ghcr.io/ddterm/gnome-shell-image/alpine-3.22:2026.07.04.0
-
-  alpine-3.23:
-    image: ghcr.io/ddterm/gnome-shell-image/alpine-3.23:2026.07.04.0
-
   alpine-3.24:
     image: ghcr.io/ddterm/gnome-shell-image/alpine-3.24:2026.07.04.0
 


### PR DESCRIPTION
Community repo is supported only for the latest release, and GNOME is part of "community" repo.

https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18306#note_628123