### PR TITLE
Revert GJS requirement to v1.80

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ schema_dir = datadir / 'glib-2.0' / 'schemas'
 applications_dir = datadir / 'applications'
 dbus_service_dir = datadir / 'dbus-1' / 'services'
 
-gjs_req = '>=1.82.0'
+gjs_req = '>=1.80.0'
 gnome_shell_req = ['>=47.0', '<51']
 shell_versions = ['47', '48', '49', '50']
 


### PR DESCRIPTION
RHEL 10 and derived distros still ship GJS 1.80 with GNOME Shell 47.