### PR TITLE
Drop support for GNOME 47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Removed
 
 - Support for GNOME 46 (Ubuntu 24.04): [#2053].
+- Support for GNOME 47: [#2068].
 
 ### Fixed
 
 [#2053]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/2053
+[#2068]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/2068
 
 [Unreleased]: https://github.com/ddterm/gnome-shell-extension-ddterm/compare/v63.2.3...HEAD
 

--- a/meson.build
+++ b/meson.build
@@ -28,8 +28,8 @@ applications_dir = datadir / 'applications'
 dbus_service_dir = datadir / 'dbus-1' / 'services'
 
 gjs_req = '>=1.80.0'
-gnome_shell_req = ['>=47.0', '<51']
-shell_versions = ['47', '48', '49', '50']
+gnome_shell_req = ['>=48.0', '<51']
+shell_versions = ['48', '49', '50']
 
 layout = get_option('layout')
 


### PR DESCRIPTION
RHEL 10 moved to GNOME Shell 49. Tests aren't running against v47 now.