### PR TITLE
prefs/appearance: move background opacity settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
+- Moved background opacity preferences from "Terminal" page to "Window":
+[#2072].
+
 [#2053]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/2053
 [#2068]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/2068
+[#2072]: https://github.com/ddterm/gnome-shell-extension-ddterm/pull/2072
 
 [Unreleased]: https://github.com/ddterm/gnome-shell-extension-ddterm/compare/v63.2.3...HEAD
 

--- a/ddterm/pref/appearance.js
+++ b/ddterm/pref/appearance.js
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk';
 
-import { PreferencesGroup } from './util.js';
+import { add_reset_button, PreferencesGroup } from './util.js';
+import { ScaleRow } from './widgets/scalerow.js';
 
 export class WindowAppearanceGroup extends PreferencesGroup {
     static [GObject.GTypeName] = 'DDTermWindowAppearanceGroup';
@@ -27,5 +30,46 @@ export class WindowAppearanceGroup extends PreferencesGroup {
                 dark: this.gettext('Dark'),
             },
         });
+
+        const opacity_adjustment = new Gtk.Adjustment({
+            upper: 1,
+            step_increment: 0.01,
+            page_increment: 0.10,
+        });
+
+        this.settings.bind(
+            'background-opacity',
+            opacity_adjustment,
+            'value',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        const opacity_row = new ScaleRow({
+            adjustment: opacity_adjustment,
+            digits: 2,
+            round_digits: 2,
+            visible: true,
+            use_underline: true,
+            title: this.gettext('_Background Opacity'),
+        });
+
+        const percent_format = new Intl.NumberFormat(undefined, { style: 'percent' });
+        opacity_row.set_format_value_func((_, v) => percent_format.format(v));
+
+        this.settings.bind_writable(
+            'background-opacity',
+            opacity_row,
+            'sensitive',
+            false
+        );
+
+        add_reset_button(opacity_row, this.settings, 'background-opacity', this.gettext_domain);
+
+        const opacity_expander = this.add_expander_row({
+            key: 'transparent-background',
+            title: this.gettext('Transparent Background'),
+        });
+
+        opacity_expander.add_row(opacity_row);
     }
 }

--- a/ddterm/pref/colors.js
+++ b/ddterm/pref/colors.js
@@ -11,7 +11,6 @@ import Gtk from 'gi://Gtk';
 
 import { ActionRow } from './widgets/actionrow.js';
 import { ComboRow, StringList } from './widgets/comborow.js';
-import { ScaleRow } from './widgets/scalerow.js';
 import { add_reset_button, PreferencesGroup, PreferencesRow } from './util.js';
 
 function show_dialog(parent_window, message, message_type = Gtk.MessageType.ERROR) {
@@ -498,47 +497,6 @@ export class ColorsGroup extends PreferencesGroup {
 
         this.#highlight_color_expander.add_row(highlight_foreground_color_row);
         this.#highlight_color_expander.add_row(highlight_background_color_row);
-
-        const opacity_adjustment = new Gtk.Adjustment({
-            upper: 1,
-            step_increment: 0.01,
-            page_increment: 0.10,
-        });
-
-        this.settings.bind(
-            'background-opacity',
-            opacity_adjustment,
-            'value',
-            Gio.SettingsBindFlags.DEFAULT
-        );
-
-        const opacity_row = new ScaleRow({
-            adjustment: opacity_adjustment,
-            digits: 2,
-            round_digits: 2,
-            visible: true,
-            use_underline: true,
-            title: this.gettext('_Background Opacity'),
-        });
-
-        const percent_format = new Intl.NumberFormat(undefined, { style: 'percent' });
-        opacity_row.set_format_value_func((_, v) => percent_format.format(v));
-
-        this.settings.bind_writable(
-            'background-opacity',
-            opacity_row,
-            'sensitive',
-            false
-        );
-
-        add_reset_button(opacity_row, this.settings, 'background-opacity', this.gettext_domain);
-
-        const opacity_expander = this.add_expander_row({
-            key: 'transparent-background',
-            title: this.gettext('Transparent Background'),
-        });
-
-        opacity_expander.add_row(opacity_row);
 
         const palette_presets = {
             [this.gettext('GNOME')]: [


### PR DESCRIPTION
Move background opacity settings from Terminal/Colors to Window/Appearance, because it controls whole window's background opacity, not just the terminal area.