### PR TITLE
translations: add separate pot.license file

### DIFF
--- a/po/ddterm@amezin.github.com.pot.license
+++ b/po/ddterm@amezin.github.com.pot.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: ddterm contributors <https://github.com/ddterm/gnome-shell-extension-ddterm/>
+SPDX-License-Identifier: GPL-3.0-or-later


### PR DESCRIPTION
Weblate generates .pot file without a copyright notice.