### PR TITLE
npm: switch back to git install of `eslint-config-gnome`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,5 +6,6 @@ git-tag-version = false
 preid = dev
 ignore-scripts = true
 allow-git = root
+allow-remote = none
 min-release-age = 3
 script-shell = bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@eslint/js": "9.39.5",
                 "argparse": "2.0.1",
                 "eslint": "9.39.5",
-                "eslint-config-gnome": "https://github.com/ddterm/eslint-config-gnome/archive/c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51.tar.gz",
+                "eslint-config-gnome": "git+https://github.com/ddterm/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51",
                 "eslint-plugin-import": "2.32.0",
                 "markdown-it": "14.3.0",
                 "markdownlint-cli2": "0.23.2",
@@ -1266,8 +1266,7 @@
         },
         "node_modules/eslint-config-gnome": {
             "version": "1.0.0",
-            "resolved": "https://github.com/ddterm/eslint-config-gnome/archive/c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51.tar.gz",
-            "integrity": "sha512-GDRPxdFnUXy89UwdH9oLtD2ECCh0n+AucyEQMvOWUJ4WOSOpNr8ek0qXaAxcFanZBjIJeDoPr1wsD5zIB3JsUw==",
+            "resolved": "git+https://github.com/ddterm/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51",
             "dev": true,
             "license": "MIT OR LGPL-2.1-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@eslint/js": "9.39.5",
         "argparse": "2.0.1",
         "eslint": "9.39.5",
-        "eslint-config-gnome": "https://github.com/ddterm/eslint-config-gnome/archive/c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51.tar.gz",
+        "eslint-config-gnome": "git+https://github.com/ddterm/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51",
         "eslint-plugin-import": "2.32.0",
         "markdown-it": "14.3.0",
         "markdownlint-cli2": "0.23.2",


### PR DESCRIPTION
- npm v12 switches `allow-remote` config from `all` to `none` by default (this breaks install of `eslint-config-gnome`).

- On Ubuntu 26.04 Actions runner images, npm 11.16.0 is installed. Hopefully, it has all git dependency bugs fixed.