### PR TITLE
npm: fix installation of `eslint-config-gnome`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,6 +5,7 @@
 git-tag-version = false
 preid = dev
 ignore-scripts = true
-allow-git = root
+allow-git = none
+allow-remote = root
 min-release-age = 3
 script-shell = bash


### PR DESCRIPTION
npm v12 switches `allow-remote` config from `all` to `none` by default.