### PR TITLE
Fix typos

### DIFF
--- a/ddterm/shell/panelicon.js
+++ b/ddterm/shell/panelicon.js
@@ -219,7 +219,7 @@ export const PanelIconProxy = GObject.registerClass({
 
     set type_name(value) {
         if (!TYPE_BY_NAME.hasOwnProperty(value))
-            throw new Error(`${value} is not a vaild icon type`);
+            throw new Error(`${value} is not a valid icon type`);
 
         const type_resolved = TYPE_BY_NAME[value];
 

--- a/tests/dbus-interfaces/org.gnome.Mutter.DisplayConfig.xml
+++ b/tests/dbus-interfaces/org.gnome.Mutter.DisplayConfig.xml
@@ -273,7 +273,7 @@
 	- -1: unknown (unsupported)
 
         A client should not attempt to change the powersave mode
-	from -1 (unknown) to any other value, and viceversa.
+	from -1 (unknown) to any other value, and vice-versa.
 	Note that the actual effects of the different values
 	depend on the hardware and the kernel driver in use, and
 	it's perfectly possible that all values different than on

--- a/tools/translate-esm.js
+++ b/tools/translate-esm.js
@@ -226,7 +226,7 @@ function translate(file, root_url, replace_imports) {
             break;
         }
         default:
-            throw new AstError(`Unknown declration type: ${node.declaration.type}`, node);
+            throw new AstError(`Unknown declaration type: ${node.declaration.type}`, node);
         }
     }
 


### PR DESCRIPTION
Found via `codespell -S po,package-lock.json -L filetest`